### PR TITLE
Add global dedup mode alongside existing one

### DIFF
--- a/demo/kill-bill/README.md
+++ b/demo/kill-bill/README.md
@@ -30,7 +30,7 @@ From this directory:
 The script does this:
 
 1. starts `ljd` in file mode
-2. writes 100 numbered OTLP log messages into one `killbill.logjet` file
+2. writes 100 numbered OTLP log messages into one `killbill.logjet` file with a short pacing delay so several physical blocks are created
 3. stops `ljd`
 4. cuts out the middle third of the file by raw bytes
 5. saves only that byte slice as `./damaged/killbill.logjet`
@@ -40,6 +40,9 @@ The script does this:
 
 The damaged file does not start on a real block boundary. Its front is just a
 raw byte slice from the middle of the original file.
+The pacing delay is intentional: it makes the demo deterministic across fast
+machines by ensuring the original file contains several independently
+recoverable blocks before the byte cut.
 
 ## Expected Result
 

--- a/demo/kill-bill/run-demo.sh
+++ b/demo/kill-bill/run-demo.sh
@@ -11,6 +11,7 @@ LOG_DIR="$SCRIPT_DIR/logs"
 DAMAGED_DIR="$SCRIPT_DIR/damaged"
 ORIGINAL_FILE="$LOG_DIR/killbill.logjet"
 DAMAGED_FILE="$DAMAGED_DIR/killbill.logjet"
+EMIT_DELAY_S=0.03
 
 for bin in "$LJD" "$EMITTER" "$COLLECTOR"; do
     if [ ! -x "$bin" ]; then
@@ -34,6 +35,7 @@ rm -rf "$LOG_DIR" "$DAMAGED_DIR"
 mkdir -p "$LOG_DIR" "$DAMAGED_DIR"
 
 echo "starting ljd to write one .logjet file with 100 messages"
+echo "pacing writes by ${EMIT_DELAY_S}s so the demo reliably produces multiple recoverable blocks"
 "$LJD" --config "$CONFIG" &
 LJD_PID=$!
 
@@ -43,6 +45,7 @@ i=1
 while [ "$i" -le 100 ]; do
     MESSAGE=$(printf 'KILL BILL %03d: the reader should recover this if its block survives the byte cut' "$i")
     "$EMITTER" 127.0.0.1:4318 --once --service-name KILL-BILL --message "$MESSAGE" >/dev/null
+    sleep "$EMIT_DELAY_S"
     i=$((i + 1))
 done
 

--- a/ljx/src/cli.rs
+++ b/ljx/src/cli.rs
@@ -55,7 +55,7 @@ pub enum Command {
     Stats(StatsArgs),
     #[command(name = "view", alias = "cat", about = "Interactively browse filtered records in a terminal UI")]
     View(ViewArgs),
-    #[command(about = "Deduplicate log records, collapsing identical or similar bodies")]
+    #[command(about = "Deduplicate log records across the whole selection or collapse nearby bursts")]
     Dedup(DedupArgs),
 }
 
@@ -67,26 +67,36 @@ pub struct DedupArgs {
     #[arg(short, long, value_name = "OUTPUT", help = "Output .logjet file or - for stdout")]
     pub output: PathBuf,
 
-    #[arg(long, value_enum, default_value_t = DedupModeArg::Hash2)]
-    pub mode: DedupModeArg,
+    #[arg(long, value_enum, default_value_t = DedupBehaviorArg::Distinct, help = "Dedup behavior: distinct across the whole selection, or collapse nearby bursts")]
+    pub mode: DedupBehaviorArg,
 
-    #[arg(long, value_name = "KEYS", help = "Comma-separated bucket extensions: scope, source_line")]
+    #[arg(long = "match", alias = "matcher", value_enum, default_value_t = DedupMatchArg::Canon, help = "Matcher level inside the selected mode: exact, canon, or full")]
+    pub matcher: DedupMatchArg,
+
+    #[arg(long, value_name = "KEYS", help = "Comma-separated bucket extensions: scope, source_line (used by collapse mode)")]
     pub bucket_by: Option<String>,
 
-    #[arg(long, value_name = "FLOAT", help = "Drain3 similarity threshold (full mode only) [default: 0.7]")]
+    #[arg(long, value_name = "FLOAT", help = "Drain3 similarity threshold (full match only) [default: 0.7]")]
     pub sim_th: Option<f64>,
 
-    #[arg(long, value_name = "INT", help = "Drain3 prefix tree depth (full mode only) [default: 3]")]
+    #[arg(long, value_name = "INT", help = "Drain3 prefix tree depth (full match only) [default: 3]")]
     pub drain_depth: Option<i64>,
 
-    #[arg(long, value_name = "DELIMS", help = "Drain3 extra delimiters, comma-separated (full mode only)")]
+    #[arg(long, value_name = "DELIMS", help = "Drain3 extra delimiters, comma-separated (full match only)")]
     pub extra_delimiters: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, ValueEnum)]
-pub enum DedupModeArg {
+pub enum DedupBehaviorArg {
+    Distinct,
+    Collapse,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum DedupMatchArg {
     Exact,
-    Hash2,
+    #[value(alias = "hash2")]
+    Canon,
     Full,
 }
 
@@ -181,5 +191,28 @@ impl From<OutputCodec> for logjet::Codec {
             OutputCodec::None => Self::None,
             OutputCodec::Lz4 => Self::Lz4,
         }
+    }
+}
+
+#[cfg(test)]
+mod cli_utst {
+    use super::{Cli, Command, DedupBehaviorArg, DedupMatchArg};
+    use clap::Parser;
+
+    #[test]
+    fn dedup_defaults_to_distinct_canon() {
+        let cli = Cli::try_parse_from(["ljx", "dedup", "input.logjet", "-o", "out.logjet"]).expect("cli parses");
+        let Command::Dedup(args) = cli.command else { panic!("expected dedup command") };
+        assert!(matches!(args.mode, DedupBehaviorArg::Distinct));
+        assert!(matches!(args.matcher, DedupMatchArg::Canon));
+    }
+
+    #[test]
+    fn dedup_accepts_collapse_and_full_matcher() {
+        let cli =
+            Cli::try_parse_from(["ljx", "dedup", "input.logjet", "-o", "out.logjet", "--mode", "collapse", "--match", "full"]).expect("cli parses");
+        let Command::Dedup(args) = cli.command else { panic!("expected dedup command") };
+        assert!(matches!(args.mode, DedupBehaviorArg::Collapse));
+        assert!(matches!(args.matcher, DedupMatchArg::Full));
     }
 }

--- a/ljx/src/commands/dedup.rs
+++ b/ljx/src/commands/dedup.rs
@@ -6,11 +6,11 @@ use logjet::{LogjetReader, LogjetWriter};
 
 use crate::cli::{DedupArgs, DedupModeArg};
 use crate::dedup::flat_record::BucketKeyKind;
-use crate::dedup::{self, DedupMode, DedupOpts, DrainOpts};
+use crate::dedup::{self, DedupMatchMode, DedupMode, DedupOpts, DrainOpts};
 use crate::error::Result;
 use crate::input::{InputHandle, open_output};
 
-impl From<DedupModeArg> for DedupMode {
+impl From<DedupModeArg> for DedupMatchMode {
     fn from(value: DedupModeArg) -> Self {
         match value {
             DedupModeArg::Exact => Self::Exact,
@@ -27,7 +27,7 @@ pub fn run(args: DedupArgs) -> Result<()> {
         depth: args.drain_depth.unwrap_or(3),
         extra_delimiters: args.extra_delimiters.as_ref().map(|s| s.split(',').map(String::from).collect()).unwrap_or_default(),
     };
-    let opts = DedupOpts { mode: args.mode.into(), bucket_key, drain };
+    let opts = DedupOpts { mode: DedupMode::Distinct, match_mode: args.mode.into(), bucket_key, drain };
 
     let input = InputHandle::open(&args.input)?;
     let mut reader = LogjetReader::new(input.into_buf_reader());

--- a/ljx/src/commands/dedup.rs
+++ b/ljx/src/commands/dedup.rs
@@ -4,18 +4,27 @@ use std::io::Write;
 
 use logjet::{LogjetReader, LogjetWriter};
 
-use crate::cli::{DedupArgs, DedupModeArg};
+use crate::cli::{DedupArgs, DedupBehaviorArg, DedupMatchArg};
 use crate::dedup::flat_record::BucketKeyKind;
 use crate::dedup::{self, DedupMatchMode, DedupMode, DedupOpts, DrainOpts};
 use crate::error::Result;
 use crate::input::{InputHandle, open_output};
 
-impl From<DedupModeArg> for DedupMatchMode {
-    fn from(value: DedupModeArg) -> Self {
+impl From<DedupBehaviorArg> for DedupMode {
+    fn from(value: DedupBehaviorArg) -> Self {
         match value {
-            DedupModeArg::Exact => Self::Exact,
-            DedupModeArg::Hash2 => Self::Hash2,
-            DedupModeArg::Full => Self::Full,
+            DedupBehaviorArg::Distinct => Self::Distinct,
+            DedupBehaviorArg::Collapse => Self::Collapse,
+        }
+    }
+}
+
+impl From<DedupMatchArg> for DedupMatchMode {
+    fn from(value: DedupMatchArg) -> Self {
+        match value {
+            DedupMatchArg::Exact => Self::Exact,
+            DedupMatchArg::Canon => Self::Hash2,
+            DedupMatchArg::Full => Self::Full,
         }
     }
 }
@@ -27,7 +36,7 @@ pub fn run(args: DedupArgs) -> Result<()> {
         depth: args.drain_depth.unwrap_or(3),
         extra_delimiters: args.extra_delimiters.as_ref().map(|s| s.split(',').map(String::from).collect()).unwrap_or_default(),
     };
-    let opts = DedupOpts { mode: DedupMode::Distinct, match_mode: args.mode.into(), bucket_key, drain };
+    let opts = DedupOpts { mode: args.mode.into(), match_mode: args.matcher.into(), bucket_key, drain };
 
     let input = InputHandle::open(&args.input)?;
     let mut reader = LogjetReader::new(input.into_buf_reader());

--- a/ljx/src/commands/view.rs
+++ b/ljx/src/commands/view.rs
@@ -1592,9 +1592,9 @@ impl ViewApp {
         let pct = (self.dedup_progress * 100.0).min(100.0);
         let label = self.dedup_completion_message.clone().unwrap_or_else(|| format!("{pct:.0}%"));
         let label_style = if self.dedup_completion_message.is_some() {
-            Style::default().fg(Color::LightYellow).add_modifier(Modifier::BOLD)
+            Style::default().fg(Color::LightYellow).bg(Color::Indexed(28)).add_modifier(Modifier::BOLD)
         } else {
-            Style::default().fg(Color::Black).add_modifier(Modifier::BOLD)
+            Style::default().fg(Color::Black).bg(Color::White).add_modifier(Modifier::BOLD)
         };
         let gauge = Gauge::default()
             .gauge_style(Style::default().fg(Color::Indexed(28)).bg(Color::White))
@@ -1903,12 +1903,15 @@ fn render_modal_info_entries(detail: &DetailRecord) -> Vec<(String, String)> {
     let mut severities = Vec::new();
     let mut event_names = Vec::new();
     let mut resource_attr_count = 0usize;
+    let mut scope_attr_count = 0usize;
     let mut record_attr_count = 0usize;
     let mut trace_ids = 0usize;
     let mut span_ids = 0usize;
     let mut resource_attr_entries = Vec::new();
+    let mut scope_attr_entries = Vec::new();
     let mut record_attr_entries = Vec::new();
     let mut resource_attr_omitted = 0usize;
+    let mut scope_attr_omitted = 0usize;
     let mut record_attr_omitted = 0usize;
 
     for resource_logs in &batch.resource_logs {
@@ -1932,6 +1935,12 @@ fn render_modal_info_entries(detail: &DetailRecord) -> Vec<(String, String)> {
                 && !scopes.iter().any(|existing| existing == &scope.name)
             {
                 scopes.push(scope.name.clone());
+            }
+            if let Some(scope) = &scope_logs.scope {
+                scope_attr_count += scope.attributes.len();
+                for attr in &scope.attributes {
+                    push_modal_attribute_entry(&mut scope_attr_entries, &mut scope_attr_omitted, "scope", &attr.key, attr.value.as_ref());
+                }
             }
             for record in &scope_logs.log_records {
                 record_attr_count += record.attributes.len();
@@ -1969,6 +1978,7 @@ fn render_modal_info_entries(detail: &DetailRecord) -> Vec<(String, String)> {
         lines.push(("event".to_string(), event_names.join(", ")));
     }
     lines.push(("resource.attrs".to_string(), resource_attr_count.to_string()));
+    lines.push(("scope.attrs".to_string(), scope_attr_count.to_string()));
     lines.push(("record.attrs".to_string(), record_attr_count.to_string()));
     for (kind, key, value) in resource_attr_entries {
         if kind.is_empty() && key.is_empty() {
@@ -1979,6 +1989,16 @@ fn render_modal_info_entries(detail: &DetailRecord) -> Vec<(String, String)> {
     }
     if resource_attr_omitted > 0 {
         lines.push(("resource.attrs.more".to_string(), format!("{resource_attr_omitted} not shown")));
+    }
+    for (kind, key, value) in scope_attr_entries {
+        if kind.is_empty() && key.is_empty() {
+            lines.push((String::new(), value));
+        } else {
+            lines.push((format!("{kind}.{key}"), value));
+        }
+    }
+    if scope_attr_omitted > 0 {
+        lines.push(("scope.attrs.more".to_string(), format!("{scope_attr_omitted} not shown")));
     }
     for (kind, key, value) in record_attr_entries {
         if kind.is_empty() && key.is_empty() {
@@ -2099,7 +2119,9 @@ fn format_any_value(value: Option<&AnyValue>) -> String {
 }
 
 fn is_otlp_attribute_entry(key: &str) -> bool {
-    (key.starts_with("resource.") && key != "resource.attrs") || (key.starts_with("record.") && key != "record.attrs")
+    (key.starts_with("resource.") && key != "resource.attrs")
+        || (key.starts_with("scope.") && key != "scope.attrs")
+        || (key.starts_with("record.") && key != "record.attrs")
 }
 
 fn is_standard_otlp_attribute_entry(key: &str) -> bool {

--- a/ljx/src/commands/view.rs
+++ b/ljx/src/commands/view.rs
@@ -25,7 +25,7 @@ use ratatui::widgets::{Block, BorderType, Borders, Clear, Gauge, Paragraph, Scro
 use ratatui::{Frame, Terminal};
 
 use crate::cli::ViewArgs;
-use crate::dedup::DedupMode;
+use crate::dedup::DedupMatchMode;
 use crate::error::{Error, Result};
 use crate::input::InputHandle;
 use crate::predicate::{FieldFilter, FilterMode, parse_filter_query};
@@ -98,7 +98,7 @@ enum DedupUpdate {
     Failed(String),
 }
 
-impl DedupMode {
+impl DedupMatchMode {
     fn label(self) -> &'static str {
         match self {
             Self::Exact => "exact",
@@ -192,7 +192,7 @@ struct ViewApp {
     field_filter_state: Option<FieldFilterState>,
     active_field_filter: FieldFilter,
     dedup_filename: String,
-    dedup_mode: DedupMode,
+    dedup_mode: DedupMatchMode,
     dedup_output_path: Option<PathBuf>,
     dedup_rx: Option<Receiver<DedupUpdate>>,
     dedup_progress: f64,
@@ -234,7 +234,7 @@ impl ViewApp {
             field_filter_state: None,
             active_field_filter: FieldFilter::default(),
             dedup_filename: String::new(),
-            dedup_mode: DedupMode::Hash2,
+            dedup_mode: DedupMatchMode::Hash2,
             dedup_output_path: None,
             dedup_rx: None,
             dedup_progress: 0.0,
@@ -840,7 +840,7 @@ impl ViewApp {
     fn open_dedup_prompt(&mut self) {
         let stem = self.input.file_stem().and_then(|s| s.to_str()).unwrap_or("output");
         self.dedup_filename = format!("{stem}-dedup.logjet");
-        self.dedup_mode = DedupMode::Hash2;
+        self.dedup_mode = DedupMatchMode::Hash2;
         self.focus = Focus::DedupPrompt;
     }
 
@@ -877,7 +877,7 @@ impl ViewApp {
         }
     }
 
-    fn start_dedup(&mut self, filename: &str, mode: DedupMode) {
+    fn start_dedup(&mut self, filename: &str, mode: DedupMatchMode) {
         let input_path = self.input.clone();
         let output_dir = self.input.parent().map(Path::to_path_buf).unwrap_or_else(|| PathBuf::from("."));
         let output_path = output_dir.join(filename);
@@ -899,7 +899,8 @@ impl ViewApp {
                 let mut writer = LogjetWriter::new(BufWriter::new(out_file));
                 tx.send(DedupUpdate::Progress(0.5)).ok();
 
-                let opts = crate::dedup::DedupOpts { mode, ..crate::dedup::DedupOpts::default() };
+                let opts =
+                    crate::dedup::DedupOpts { mode: crate::dedup::DedupMode::Distinct, match_mode: mode, ..crate::dedup::DedupOpts::default() };
                 let stats = crate::dedup::dedup(unpacked.records, unpacked.passthrough, &mut writer, &opts).map_err(|e| e.to_string())?;
 
                 tx.send(DedupUpdate::Progress(0.9)).ok();

--- a/ljx/src/commands/view.rs
+++ b/ljx/src/commands/view.rs
@@ -226,6 +226,7 @@ struct ViewApp {
     dedup_progress: f64,
     dedup_progress_target: f64,
     dedup_phase: String,
+    dedup_completion_message: Option<String>,
 }
 
 impl ViewApp {
@@ -271,6 +272,7 @@ impl ViewApp {
             dedup_progress: 0.0,
             dedup_progress_target: 0.0,
             dedup_phase: String::new(),
+            dedup_completion_message: None,
         })
     }
 
@@ -304,7 +306,7 @@ impl ViewApp {
             Focus::SavePrompt => self.handle_save_prompt_key(key),
             Focus::SaveError => self.handle_save_error_key(),
             Focus::DedupPrompt => self.handle_dedup_prompt_key(key),
-            Focus::DedupProgress => Ok(false),
+            Focus::DedupProgress => self.handle_dedup_progress_key(key),
             Focus::Search => self.handle_search_key(key),
             Focus::List => self.handle_list_key(key),
         }
@@ -929,6 +931,7 @@ impl ViewApp {
         self.dedup_progress = 0.0;
         self.dedup_progress_target = 0.0;
         self.dedup_phase = "starting".to_string();
+        self.dedup_completion_message = None;
         self.focus = Focus::DedupProgress;
 
         thread::spawn(move || {
@@ -975,15 +978,9 @@ impl ViewApp {
                 DedupUpdate::Done { total, groups, pct } => {
                     self.dedup_progress = 1.0;
                     self.dedup_progress_target = 1.0;
-                    self.dedup_phase = "done".to_string();
+                    self.dedup_phase = "OK".to_string();
                     self.dedup_rx = None;
-                    let msg = format!("Dedup: {total} → {groups} ({pct:.1}% reduction)");
-                    if let Some(path) = self.dedup_output_path.take() {
-                        let _ = self.switch_to_file(path);
-                    } else {
-                        self.focus = Focus::List;
-                    }
-                    self.status = msg;
+                    self.dedup_completion_message = Some(format!("{total} records → {groups} groups ({pct:.1}% reduction)"));
                     return;
                 }
                 DedupUpdate::Failed(e) => {
@@ -997,6 +994,34 @@ impl ViewApp {
         }
         if self.dedup_progress < self.dedup_progress_target {
             self.dedup_progress = (self.dedup_progress + 0.015).min(self.dedup_progress_target);
+        }
+    }
+
+    fn handle_dedup_progress_key(&mut self, key: KeyEvent) -> Result<bool> {
+        if self.dedup_rx.is_some() {
+            return Ok(false);
+        }
+
+        match key.code {
+            KeyCode::Enter => {
+                let msg = self.dedup_completion_message.take();
+                if let Some(path) = self.dedup_output_path.take() {
+                    self.switch_to_file(path)?;
+                } else {
+                    self.focus = Focus::List;
+                }
+                if let Some(msg) = msg {
+                    self.status = format!("Dedup: {msg}");
+                }
+                Ok(false)
+            }
+            KeyCode::Esc => {
+                self.dedup_completion_message = None;
+                self.dedup_output_path = None;
+                self.focus = Focus::List;
+                Ok(false)
+            }
+            _ => Ok(false),
         }
     }
 
@@ -1565,18 +1590,24 @@ impl ViewApp {
         frame.render_widget(block, area);
 
         let pct = (self.dedup_progress * 100.0).min(100.0);
-        let label = format!("{pct:.0}%");
+        let label = self.dedup_completion_message.clone().unwrap_or_else(|| format!("{pct:.0}%"));
+        let label_style = if self.dedup_completion_message.is_some() {
+            Style::default().fg(Color::LightYellow).add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(Color::Black).add_modifier(Modifier::BOLD)
+        };
         let gauge = Gauge::default()
             .gauge_style(Style::default().fg(Color::Indexed(28)).bg(Color::White))
-            .label(Span::styled(label, Style::default().fg(Color::Black).add_modifier(Modifier::BOLD)))
+            .label(Span::styled(label, label_style))
             .ratio(self.dedup_progress.clamp(0.0, 1.0));
         let bar_area = Rect { x: inner.x + 1, y: inner.y + 1, width: inner.width.saturating_sub(2), height: 1 };
         frame.render_widget(gauge, bar_area);
         let phase_area = Rect { x: inner.x + 1, y: inner.y + 3, width: inner.width.saturating_sub(2), height: 1 };
+        let phase_text = if self.dedup_completion_message.is_some() { "Press ENTER to open the deduped file" } else { self.dedup_phase.as_str() };
         frame.render_widget(
             Paragraph::new(Line::from(vec![
                 Span::styled("Phase: ", Style::default().fg(Color::Black).bg(Color::Gray).add_modifier(Modifier::BOLD)),
-                Span::styled(self.dedup_phase.as_str(), Style::default().fg(Color::DarkGray).bg(Color::Gray)),
+                Span::styled(phase_text, Style::default().fg(Color::DarkGray).bg(Color::Gray)),
             ])),
             phase_area,
         );

--- a/ljx/src/commands/view.rs
+++ b/ljx/src/commands/view.rs
@@ -25,7 +25,7 @@ use ratatui::widgets::{Block, BorderType, Borders, Clear, Gauge, Paragraph, Scro
 use ratatui::{Frame, Terminal};
 
 use crate::cli::ViewArgs;
-use crate::dedup::DedupMatchMode;
+use crate::dedup::{DedupMatchMode, DedupMode};
 use crate::error::{Error, Result};
 use crate::input::InputHandle;
 use crate::predicate::{FieldFilter, FilterMode, parse_filter_query};
@@ -93,16 +93,43 @@ enum ScanUpdate {
 
 #[derive(Debug, Clone)]
 enum DedupUpdate {
-    Progress(f64),
+    Progress { ratio: f64, phase: String },
     Done { total: u64, groups: u64, pct: f64 },
     Failed(String),
+}
+
+impl DedupMode {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Distinct => "distinct",
+            Self::Collapse => "collapse",
+        }
+    }
+
+    fn description(self) -> &'static str {
+        match self {
+            Self::Distinct => "whole filtered set, SQL-like distinct",
+            Self::Collapse => "nearby burst suppression within bucket",
+        }
+    }
+
+    fn next(self) -> Self {
+        match self {
+            Self::Distinct => Self::Collapse,
+            Self::Collapse => Self::Distinct,
+        }
+    }
+
+    fn prev(self) -> Self {
+        self.next()
+    }
 }
 
 impl DedupMatchMode {
     fn label(self) -> &'static str {
         match self {
             Self::Exact => "exact",
-            Self::Hash2 => "hash2",
+            Self::Hash2 => "canon",
             Self::Full => "full",
         }
     }
@@ -110,8 +137,8 @@ impl DedupMatchMode {
     fn description(self) -> &'static str {
         match self {
             Self::Exact => "byte-identical bodies only",
-            Self::Hash2 => "canonical body grouping",
-            Self::Full => "hash2 plus Drain3 residuals",
+            Self::Hash2 => "canonicalized body grouping",
+            Self::Full => "canon plus Drain3 residuals",
         }
     }
 
@@ -192,10 +219,13 @@ struct ViewApp {
     field_filter_state: Option<FieldFilterState>,
     active_field_filter: FieldFilter,
     dedup_filename: String,
-    dedup_mode: DedupMatchMode,
+    dedup_behavior: DedupMode,
+    dedup_match_mode: DedupMatchMode,
     dedup_output_path: Option<PathBuf>,
     dedup_rx: Option<Receiver<DedupUpdate>>,
     dedup_progress: f64,
+    dedup_progress_target: f64,
+    dedup_phase: String,
 }
 
 impl ViewApp {
@@ -234,10 +264,13 @@ impl ViewApp {
             field_filter_state: None,
             active_field_filter: FieldFilter::default(),
             dedup_filename: String::new(),
-            dedup_mode: DedupMatchMode::Hash2,
+            dedup_behavior: DedupMode::Distinct,
+            dedup_match_mode: DedupMatchMode::Hash2,
             dedup_output_path: None,
             dedup_rx: None,
             dedup_progress: 0.0,
+            dedup_progress_target: 0.0,
+            dedup_phase: String::new(),
         })
     }
 
@@ -840,7 +873,8 @@ impl ViewApp {
     fn open_dedup_prompt(&mut self) {
         let stem = self.input.file_stem().and_then(|s| s.to_str()).unwrap_or("output");
         self.dedup_filename = format!("{stem}-dedup.logjet");
-        self.dedup_mode = DedupMatchMode::Hash2;
+        self.dedup_behavior = DedupMode::Distinct;
+        self.dedup_match_mode = DedupMatchMode::Hash2;
         self.focus = Focus::DedupPrompt;
     }
 
@@ -849,7 +883,7 @@ impl ViewApp {
             KeyCode::Enter => {
                 let filename = self.dedup_filename.clone();
                 if !filename.is_empty() {
-                    self.start_dedup(&filename, self.dedup_mode);
+                    self.start_dedup(&filename, self.dedup_behavior, self.dedup_match_mode);
                 }
                 Ok(false)
             }
@@ -857,12 +891,20 @@ impl ViewApp {
                 self.focus = Focus::List;
                 Ok(false)
             }
-            KeyCode::Left | KeyCode::Up => {
-                self.dedup_mode = self.dedup_mode.prev();
+            KeyCode::Left => {
+                self.dedup_behavior = self.dedup_behavior.prev();
                 Ok(false)
             }
-            KeyCode::Right | KeyCode::Down | KeyCode::Tab => {
-                self.dedup_mode = self.dedup_mode.next();
+            KeyCode::Right => {
+                self.dedup_behavior = self.dedup_behavior.next();
+                Ok(false)
+            }
+            KeyCode::Up => {
+                self.dedup_match_mode = self.dedup_match_mode.prev();
+                Ok(false)
+            }
+            KeyCode::Down | KeyCode::Tab => {
+                self.dedup_match_mode = self.dedup_match_mode.next();
                 Ok(false)
             }
             KeyCode::Backspace => {
@@ -877,7 +919,7 @@ impl ViewApp {
         }
     }
 
-    fn start_dedup(&mut self, filename: &str, mode: DedupMatchMode) {
+    fn start_dedup(&mut self, filename: &str, behavior: DedupMode, match_mode: DedupMatchMode) {
         let input_path = self.input.clone();
         let output_dir = self.input.parent().map(Path::to_path_buf).unwrap_or_else(|| PathBuf::from("."));
         let output_path = output_dir.join(filename);
@@ -885,25 +927,28 @@ impl ViewApp {
         self.dedup_rx = Some(rx);
         self.dedup_output_path = Some(output_path.clone());
         self.dedup_progress = 0.0;
+        self.dedup_progress_target = 0.0;
+        self.dedup_phase = "starting".to_string();
         self.focus = Focus::DedupProgress;
 
         thread::spawn(move || {
             let run = || -> std::result::Result<crate::dedup::DedupStats, String> {
-                tx.send(DedupUpdate::Progress(0.1)).ok();
+                tx.send(DedupUpdate::Progress { ratio: 0.05, phase: "opening input".to_string() }).ok();
                 let input = crate::input::InputHandle::open(&input_path).map_err(|e| e.to_string())?;
+                tx.send(DedupUpdate::Progress { ratio: 0.18, phase: "unpacking records".to_string() }).ok();
                 let mut reader = LogjetReader::new(input.into_buf_reader());
                 let unpacked = crate::dedup::unpack::unpack(&mut reader).map_err(|e| e.to_string())?;
-                tx.send(DedupUpdate::Progress(0.3)).ok();
+                tx.send(DedupUpdate::Progress { ratio: 0.32, phase: "preparing output".to_string() }).ok();
 
                 let out_file = File::create(&output_path).map_err(|e| e.to_string())?;
                 let mut writer = LogjetWriter::new(BufWriter::new(out_file));
-                tx.send(DedupUpdate::Progress(0.5)).ok();
+                let phase = format!("running {} / {}", behavior.label(), match_mode.label());
+                tx.send(DedupUpdate::Progress { ratio: 0.82, phase }).ok();
 
-                let opts =
-                    crate::dedup::DedupOpts { mode: crate::dedup::DedupMode::Distinct, match_mode: mode, ..crate::dedup::DedupOpts::default() };
+                let opts = crate::dedup::DedupOpts { mode: behavior, match_mode, ..crate::dedup::DedupOpts::default() };
                 let stats = crate::dedup::dedup(unpacked.records, unpacked.passthrough, &mut writer, &opts).map_err(|e| e.to_string())?;
 
-                tx.send(DedupUpdate::Progress(0.9)).ok();
+                tx.send(DedupUpdate::Progress { ratio: 0.94, phase: "flushing output".to_string() }).ok();
                 let mut out = writer.into_inner().map_err(|e| e.to_string())?;
                 out.flush().map_err(|e| e.to_string())?;
                 Ok(stats)
@@ -923,9 +968,14 @@ impl ViewApp {
         let Some(rx) = &self.dedup_rx else { return };
         while let Ok(update) = rx.try_recv() {
             match update {
-                DedupUpdate::Progress(p) => self.dedup_progress = p,
+                DedupUpdate::Progress { ratio, phase } => {
+                    self.dedup_progress_target = ratio;
+                    self.dedup_phase = phase;
+                }
                 DedupUpdate::Done { total, groups, pct } => {
                     self.dedup_progress = 1.0;
+                    self.dedup_progress_target = 1.0;
+                    self.dedup_phase = "done".to_string();
                     self.dedup_rx = None;
                     let msg = format!("Dedup: {total} → {groups} ({pct:.1}% reduction)");
                     if let Some(path) = self.dedup_output_path.take() {
@@ -944,6 +994,9 @@ impl ViewApp {
                     return;
                 }
             }
+        }
+        if self.dedup_progress < self.dedup_progress_target {
+            self.dedup_progress = (self.dedup_progress + 0.015).min(self.dedup_progress_target);
         }
     }
 
@@ -1465,19 +1518,31 @@ impl ViewApp {
         frame.render_widget(
             Paragraph::new(Line::from(vec![
                 Span::styled("Mode:   ", Style::default().fg(Color::Black).bg(Color::Gray)),
-                Span::styled(self.dedup_mode.label(), Style::default().fg(Color::Black).bg(Color::White).add_modifier(Modifier::BOLD)),
-                Span::styled(format!("  {}", self.dedup_mode.description()), Style::default().fg(Color::DarkGray).bg(Color::Gray)),
+                Span::styled(self.dedup_behavior.label(), Style::default().fg(Color::Black).bg(Color::White).add_modifier(Modifier::BOLD)),
+                Span::styled(format!("  {}", self.dedup_behavior.description()), Style::default().fg(Color::DarkGray).bg(Color::Gray)),
             ])),
             mode_row,
         );
 
+        let matcher_row = Rect { x: inner.x, y: inner.y.saturating_add(3), width: inner.width, height: 1 };
+        frame.render_widget(
+            Paragraph::new(Line::from(vec![
+                Span::styled("Match:  ", Style::default().fg(Color::Black).bg(Color::Gray)),
+                Span::styled(self.dedup_match_mode.label(), Style::default().fg(Color::Black).bg(Color::White).add_modifier(Modifier::BOLD)),
+                Span::styled(format!("  {}", self.dedup_match_mode.description()), Style::default().fg(Color::DarkGray).bg(Color::Gray)),
+            ])),
+            matcher_row,
+        );
+
         // Footer hint
-        let hint_y = inner.y.saturating_add(4).min(inner.y + inner.height.saturating_sub(1));
+        let hint_y = inner.y.saturating_add(5).min(inner.y + inner.height.saturating_sub(1));
         let hint_area = Rect { x: inner.x, y: hint_y, width: inner.width, height: 1 };
         frame.render_widget(
             Paragraph::new(Line::from(vec![
                 Span::styled("←/→", Style::default().fg(Color::Black).bg(Color::Gray).add_modifier(Modifier::BOLD)),
                 Span::styled(" mode   ", Style::default().fg(Color::DarkGray).bg(Color::Gray)),
+                Span::styled("↑/↓", Style::default().fg(Color::Black).bg(Color::Gray).add_modifier(Modifier::BOLD)),
+                Span::styled(" match   ", Style::default().fg(Color::DarkGray).bg(Color::Gray)),
                 Span::styled("ENTER", Style::default().fg(Color::Black).bg(Color::Gray).add_modifier(Modifier::BOLD)),
                 Span::styled(" start   ", Style::default().fg(Color::DarkGray).bg(Color::Gray)),
                 Span::styled("ESC", Style::default().fg(Color::Black).bg(Color::Gray).add_modifier(Modifier::BOLD)),
@@ -1507,6 +1572,14 @@ impl ViewApp {
             .ratio(self.dedup_progress.clamp(0.0, 1.0));
         let bar_area = Rect { x: inner.x + 1, y: inner.y + 1, width: inner.width.saturating_sub(2), height: 1 };
         frame.render_widget(gauge, bar_area);
+        let phase_area = Rect { x: inner.x + 1, y: inner.y + 3, width: inner.width.saturating_sub(2), height: 1 };
+        frame.render_widget(
+            Paragraph::new(Line::from(vec![
+                Span::styled("Phase: ", Style::default().fg(Color::Black).bg(Color::Gray).add_modifier(Modifier::BOLD)),
+                Span::styled(self.dedup_phase.as_str(), Style::default().fg(Color::DarkGray).bg(Color::Gray)),
+            ])),
+            phase_area,
+        );
     }
 
     fn switch_to_file(&mut self, path: PathBuf) -> Result<()> {

--- a/ljx/src/commands/view_ut.rs
+++ b/ljx/src/commands/view_ut.rs
@@ -348,3 +348,56 @@ fn dedup_progress_updates_target_and_eases_displayed_progress() {
 
     let _ = std::fs::remove_file(input);
 }
+
+#[test]
+fn dedup_done_keeps_popup_open_until_enter() {
+    let input = create_temp_path().unwrap();
+    let output = create_temp_path().unwrap();
+    write_test_logjet(&input, &["placeholder route update"]);
+    write_test_logjet(&output, &["placeholder route update"]);
+
+    let mut app = make_view_app(input.clone());
+    let (tx, rx) = mpsc::channel();
+    app.dedup_rx = Some(rx);
+    app.dedup_output_path = Some(output.clone());
+    app.focus = Focus::DedupProgress;
+
+    tx.send(DedupUpdate::Done { total: 94102, groups: 9039, pct: 90.4 }).unwrap();
+    drop(tx);
+
+    app.drain_dedup_updates();
+
+    assert!(matches!(app.focus, Focus::DedupProgress));
+    assert_eq!(app.dedup_progress, 1.0);
+    assert_eq!(app.dedup_phase, "OK");
+    assert_eq!(app.dedup_completion_message.as_deref(), Some("94102 records → 9039 groups (90.4% reduction)"));
+
+    let _ = std::fs::remove_file(input);
+    let _ = std::fs::remove_file(output);
+}
+
+#[test]
+fn dedup_progress_enter_opens_output_and_sets_status() {
+    let input = create_temp_path().unwrap();
+    let output = create_temp_path().unwrap();
+    write_test_logjet(&input, &["placeholder route update"]);
+    write_test_logjet(&output, &["placeholder route update"]);
+
+    let mut app = make_view_app(input.clone());
+    app.focus = Focus::DedupProgress;
+    app.dedup_output_path = Some(output.clone());
+    app.dedup_completion_message = Some("10 records → 2 groups (80.0% reduction)".to_string());
+    app.dedup_progress = 1.0;
+    app.dedup_progress_target = 1.0;
+    app.dedup_phase = "OK".to_string();
+
+    app.handle_dedup_progress_key(key(KeyCode::Enter)).unwrap();
+
+    assert!(matches!(app.focus, Focus::List));
+    assert!(app.status.contains("10 records → 2 groups (80.0% reduction)"));
+    assert_eq!(app.input, output);
+    assert!(app.dedup_completion_message.is_none());
+
+    let _ = std::fs::remove_file(input);
+    let _ = std::fs::remove_file(output);
+}

--- a/ljx/src/commands/view_ut.rs
+++ b/ljx/src/commands/view_ut.rs
@@ -98,7 +98,17 @@ fn modal_info_lists_otlp_attributes() {
                 scope: Some(InstrumentationScope {
                     name: "liblogjet".to_string(),
                     version: String::new(),
-                    attributes: Vec::new(),
+                    attributes: vec![KeyValue {
+                        key: "esotrace.channel".to_string(),
+                        value: Some(AnyValue {
+                            value: Some(Value::ArrayValue(opentelemetry_proto::tonic::common::v1::ArrayValue {
+                                values: vec![
+                                    AnyValue { value: Some(Value::StringValue("de".to_string())) },
+                                    AnyValue { value: Some(Value::StringValue("eso".to_string())) },
+                                ],
+                            })),
+                        }),
+                    }],
                     dropped_attributes_count: 0,
                 }),
                 log_records: vec![LogRecord {
@@ -130,13 +140,21 @@ fn modal_info_lists_otlp_attributes() {
 
     let entries = render_modal_info_entries(&detail);
     assert!(entries.iter().any(|(key, value)| key == "resource.service.name" && value == "cpp-appliance"));
+    assert!(entries.iter().any(|(key, value)| key == "scope.esotrace.channel" && value == "de"));
+    assert!(entries.iter().any(|(key, value)| key.is_empty() && value == "eso"));
     assert!(entries.iter().any(|(key, value)| key == "record.character" && value == "Bender"));
 }
 
 #[test]
 fn modal_info_caps_attribute_entries_per_kind() {
-    let attributes = (0..40)
+    let record_attributes = (0..40)
         .map(|index| KeyValue { key: format!("custom.{index}"), value: Some(AnyValue { value: Some(Value::StringValue(format!("value-{index}"))) }) })
+        .collect::<Vec<_>>();
+    let scope_attributes = (0..40)
+        .map(|index| KeyValue {
+            key: format!("scope.custom.{index}"),
+            value: Some(AnyValue { value: Some(Value::StringValue(format!("scope-value-{index}"))) }),
+        })
         .collect::<Vec<_>>();
     let batch = ExportLogsServiceRequest {
         resource_logs: vec![ResourceLogs {
@@ -145,7 +163,7 @@ fn modal_info_caps_attribute_entries_per_kind() {
                 scope: Some(InstrumentationScope {
                     name: "liblogjet".to_string(),
                     version: String::new(),
-                    attributes: Vec::new(),
+                    attributes: scope_attributes,
                     dropped_attributes_count: 0,
                 }),
                 log_records: vec![LogRecord {
@@ -154,7 +172,7 @@ fn modal_info_caps_attribute_entries_per_kind() {
                     severity_number: 0,
                     severity_text: "INFO".to_string(),
                     body: Some(AnyValue { value: Some(Value::StringValue("hello from cpp".to_string())) }),
-                    attributes,
+                    attributes: record_attributes,
                     dropped_attributes_count: 0,
                     flags: 0,
                     trace_id: Vec::new(),
@@ -173,7 +191,10 @@ fn modal_info_caps_attribute_entries_per_kind() {
     };
 
     let entries = render_modal_info_entries(&detail);
+    let scope_entries = entries.iter().filter(|(key, _)| key.starts_with("scope.scope.custom.")).count();
     let record_entries = entries.iter().filter(|(key, _)| key.starts_with("record.custom.")).count();
+    assert_eq!(scope_entries, MODAL_ATTR_ENTRY_LIMIT_PER_KIND);
+    assert!(entries.iter().any(|(key, value)| key == "scope.attrs.more" && value == "8 not shown"));
     assert_eq!(record_entries, MODAL_ATTR_ENTRY_LIMIT_PER_KIND);
     assert!(entries.iter().any(|(key, value)| key == "record.attrs.more" && value == "8 not shown"));
 }

--- a/ljx/src/commands/view_ut.rs
+++ b/ljx/src/commands/view_ut.rs
@@ -1,15 +1,21 @@
 use super::{
-    DetailRecord, EntryMeta, MODAL_ATTR_ENTRY_LIMIT_PER_KIND, extract_otlp_log_message, format_summary, open_temp_spool_pair, read_spool_record,
-    render_modal_info_entries, render_modal_message, text_preview, write_spool_record,
+    DedupUpdate, DetailRecord, EntryMeta, Focus, MODAL_ATTR_ENTRY_LIMIT_PER_KIND, ViewApp, create_temp_path, extract_otlp_log_message,
+    format_summary, open_temp_spool_pair, read_spool_record, render_modal_info_entries, render_modal_message, text_preview, write_spool_record,
 };
+use crate::cli::ViewArgs;
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use logjet::OwnedRecord;
-use logjet::RecordType;
+use logjet::{LogjetWriter, RecordType};
 use opentelemetry_proto::tonic::collector::logs::v1::ExportLogsServiceRequest;
 use opentelemetry_proto::tonic::common::v1::any_value::Value;
 use opentelemetry_proto::tonic::common::v1::{AnyValue, InstrumentationScope, KeyValue};
 use opentelemetry_proto::tonic::logs::v1::{LogRecord, ResourceLogs, ScopeLogs};
 use opentelemetry_proto::tonic::resource::v1::Resource;
 use prost::Message;
+use std::fs::File;
+use std::io::BufWriter;
+use std::sync::mpsc;
+use std::time::Duration;
 
 #[test]
 fn text_preview_flattens_newlines() {
@@ -191,4 +197,154 @@ fn temp_spool_reader_and_writer_use_independent_offsets() {
     assert_eq!(reread_second.payload, second.payload);
 
     let _ = std::fs::remove_file(path);
+}
+
+fn make_view_app(input: std::path::PathBuf) -> ViewApp {
+    ViewApp::new(ViewArgs { input, hex_payload: false }).expect("view app")
+}
+
+fn key(code: KeyCode) -> KeyEvent {
+    KeyEvent::new(code, KeyModifiers::NONE)
+}
+
+fn write_test_logjet(path: &std::path::Path, bodies: &[&str]) {
+    let batch = ExportLogsServiceRequest {
+        resource_logs: vec![ResourceLogs {
+            resource: Some(Resource {
+                attributes: vec![KeyValue {
+                    key: "service.name".to_string(),
+                    value: Some(AnyValue { value: Some(Value::StringValue("fake-service".to_string())) }),
+                }],
+                dropped_attributes_count: 0,
+                entity_refs: Vec::new(),
+            }),
+            scope_logs: vec![ScopeLogs {
+                scope: Some(InstrumentationScope {
+                    name: "fake-scope".to_string(),
+                    version: String::new(),
+                    attributes: Vec::new(),
+                    dropped_attributes_count: 0,
+                }),
+                log_records: bodies
+                    .iter()
+                    .enumerate()
+                    .map(|(i, body)| LogRecord {
+                        time_unix_nano: (i as u64 + 1) * 100,
+                        observed_time_unix_nano: (i as u64 + 1) * 100,
+                        severity_number: 9,
+                        severity_text: "INFO".to_string(),
+                        body: Some(AnyValue { value: Some(Value::StringValue((*body).to_string())) }),
+                        attributes: Vec::new(),
+                        dropped_attributes_count: 0,
+                        flags: 0,
+                        trace_id: Vec::new(),
+                        span_id: Vec::new(),
+                        event_name: String::new(),
+                    })
+                    .collect(),
+                schema_url: String::new(),
+            }],
+            schema_url: String::new(),
+        }],
+    };
+
+    let file = File::create(path).expect("create input logjet");
+    let mut writer = LogjetWriter::new(BufWriter::new(file));
+    let payload = batch.encode_to_vec();
+    writer.push(RecordType::Logs, 1, 100, &payload).expect("write record");
+    let mut inner = writer.into_inner().expect("into inner");
+    use std::io::Write;
+    inner.flush().expect("flush");
+}
+
+fn read_first_log_record(path: &std::path::Path) -> LogRecord {
+    let bytes = std::fs::read(path).expect("read output file");
+    let cursor = std::io::Cursor::new(bytes);
+    let mut reader = logjet::LogjetReader::new(cursor);
+    while let Some(rec) = reader.next_record().expect("next record") {
+        if rec.record_type != RecordType::Logs {
+            continue;
+        }
+        let batch = ExportLogsServiceRequest::decode(rec.payload.as_slice()).expect("decode batch");
+        return batch.resource_logs[0].scope_logs[0].log_records[0].clone();
+    }
+    panic!("no log record in output");
+}
+
+fn find_attr_str(record: &LogRecord, key: &str) -> Option<String> {
+    record.attributes.iter().find(|a| a.key == key).and_then(|a| match &a.value {
+        Some(AnyValue { value: Some(Value::StringValue(s)) }) => Some(s.clone()),
+        _ => None,
+    })
+}
+
+#[test]
+fn dedup_prompt_switches_behaviour_and_matcher_independently() {
+    let input = create_temp_path().unwrap();
+    let mut app = make_view_app(input.clone());
+    app.open_dedup_prompt();
+
+    assert!(matches!(app.focus, Focus::DedupPrompt));
+    assert_eq!(app.dedup_behavior.label(), "distinct");
+    assert_eq!(app.dedup_match_mode.label(), "canon");
+
+    app.handle_dedup_prompt_key(key(KeyCode::Right)).unwrap();
+    assert_eq!(app.dedup_behavior.label(), "collapse");
+    assert_eq!(app.dedup_match_mode.label(), "canon");
+
+    app.handle_dedup_prompt_key(key(KeyCode::Down)).unwrap();
+    assert_eq!(app.dedup_behavior.label(), "collapse");
+    assert_eq!(app.dedup_match_mode.label(), "full");
+
+    let _ = std::fs::remove_file(input);
+}
+
+#[test]
+fn dedup_worker_uses_selected_behaviour_and_matcher() {
+    let input = create_temp_path().unwrap();
+    write_test_logjet(&input, &["lapsed time is 2", "lapsed time is 3"]);
+
+    let mut app = make_view_app(input.clone());
+    app.start_dedup("dedup-out.logjet", crate::dedup::DedupMode::Collapse, crate::dedup::DedupMatchMode::Full);
+
+    let rx = app.dedup_rx.take().expect("dedup receiver");
+    let output_path = app.dedup_output_path.clone().expect("output path");
+
+    loop {
+        match rx.recv_timeout(Duration::from_secs(5)).expect("dedup update") {
+            DedupUpdate::Done { .. } => break,
+            DedupUpdate::Failed(err) => panic!("dedup failed: {err}"),
+            DedupUpdate::Progress { .. } => {}
+        }
+    }
+
+    let record = read_first_log_record(&output_path);
+    assert_eq!(find_attr_str(&record, "dedup.behaviour").as_deref(), Some("collapse"));
+    assert_eq!(find_attr_str(&record, "dedup.matcher").as_deref(), Some("drain3"));
+    assert_eq!(find_attr_str(&record, "dedup.window").as_deref(), Some("consecutive-run"));
+
+    let _ = std::fs::remove_file(input);
+    let _ = std::fs::remove_file(output_path);
+}
+
+#[test]
+fn dedup_progress_updates_target_and_eases_displayed_progress() {
+    let input = create_temp_path().unwrap();
+    let mut app = make_view_app(input.clone());
+    let (tx, rx) = mpsc::channel();
+    app.dedup_rx = Some(rx);
+    app.dedup_progress = 0.10;
+    app.dedup_progress_target = 0.10;
+
+    tx.send(DedupUpdate::Progress { ratio: 0.80, phase: "running collapse / full".to_string() }).unwrap();
+    drop(tx);
+
+    app.drain_dedup_updates();
+
+    assert_eq!(app.dedup_progress_target, 0.80);
+    assert_eq!(app.dedup_phase, "running collapse / full");
+    assert!(app.dedup_progress > 0.10);
+    assert!(app.dedup_progress < 0.80);
+
+    let _ = std::fs::remove_file(input);
 }

--- a/ljx/src/dedup/bucket.rs
+++ b/ljx/src/dedup/bucket.rs
@@ -1,7 +1,7 @@
 //! Stage 1: group flat records by bucket key.
 //!
-//! Produces a `HashMap<BucketKey, Vec<FlatRecord>>`. All downstream dedup
-//! is bucket-local — records in different buckets never merge.
+//! Produces a `HashMap<BucketKey, Vec<FlatRecord>>`. Downstream dedup is
+//! bucket-local unless the selected mode requests the synthetic global bucket.
 
 use std::collections::HashMap;
 

--- a/ljx/src/dedup/canon.rs
+++ b/ljx/src/dedup/canon.rs
@@ -47,7 +47,7 @@ pub fn canon_dedup(mut groups: Vec<DedupGroup>) -> Vec<DedupGroup> {
 }
 
 /// Canonicalise a body string, returning (canonical_form, shape_label).
-fn canonicalise_body(body: &str) -> (String, String) {
+pub(crate) fn canonicalise_body(body: &str) -> (String, String) {
     let detected = detect(body);
     match detected.shape {
         BodyShape::Json => {

--- a/ljx/src/dedup/collapse.rs
+++ b/ljx/src/dedup/collapse.rs
@@ -1,0 +1,99 @@
+//! Local / burst-oriented deduplication.
+//!
+//! This mode preserves ordering and only merges records into the current
+//! trailing group when they belong to the same bucket and match the active
+//! matcher level. Once a different record starts a new run, later repeats
+//! become new groups.
+
+use xxhash_rust::xxh3::xxh3_64;
+
+use crate::dedup::canon::canonicalise_body;
+use crate::dedup::drain3::{Drain, DrainConfig};
+use crate::dedup::flat_record::{BucketKey, FlatRecord};
+use crate::dedup::{DedupGroup, DedupMatchMode, DedupOpts};
+
+pub fn dedup(records: Vec<FlatRecord>, opts: &DedupOpts) -> Vec<DedupGroup> {
+    let mut groups: Vec<DedupGroup> = Vec::new();
+
+    for rec in records {
+        let bucket_key = BucketKey::from_record(&rec, opts.bucket_key);
+        let candidate = CollapseCandidate::from_record(rec, bucket_key, opts.match_mode);
+
+        if let Some(last) = groups.last_mut()
+            && last.bucket_key == candidate.bucket_key
+            && (same_signature(last, &candidate) || (opts.match_mode == DedupMatchMode::Full && drain_matches(last, &candidate, opts)))
+        {
+            merge_into_group(last, candidate);
+            continue;
+        }
+
+        groups.push(candidate.into_group());
+    }
+
+    groups
+}
+
+struct CollapseCandidate {
+    bucket_key: BucketKey,
+    signature: u64,
+    canonical_body: Option<String>,
+    body_shape: Option<String>,
+    record: FlatRecord,
+}
+
+impl CollapseCandidate {
+    fn from_record(record: FlatRecord, bucket_key: BucketKey, match_mode: DedupMatchMode) -> Self {
+        match match_mode {
+            DedupMatchMode::Exact => {
+                let signature = xxh3_64(record.body.as_bytes());
+                Self { bucket_key, signature, canonical_body: None, body_shape: None, record }
+            }
+            DedupMatchMode::Hash2 | DedupMatchMode::Full => {
+                let (canonical_body, body_shape) = canonicalise_body(&record.body);
+                let signature = xxh3_64(canonical_body.as_bytes());
+                Self { bucket_key, signature, canonical_body: Some(canonical_body), body_shape: Some(body_shape), record }
+            }
+        }
+    }
+
+    fn into_group(self) -> DedupGroup {
+        let mut group = DedupGroup::new(self.bucket_key, self.signature, self.record);
+        group.canonical_body = self.canonical_body;
+        group.body_shape = self.body_shape;
+        group
+    }
+}
+
+fn same_signature(group: &DedupGroup, candidate: &CollapseCandidate) -> bool {
+    group.signature == candidate.signature
+}
+
+fn merge_into_group(group: &mut DedupGroup, candidate: CollapseCandidate) {
+    group.absorb(&candidate.record);
+}
+
+fn drain_matches(group: &mut DedupGroup, candidate: &CollapseCandidate, opts: &DedupOpts) -> bool {
+    let left = group.drain3_template.as_deref().or(group.canonical_body.as_deref()).unwrap_or(&group.representative.body);
+    let right = candidate.canonical_body.as_deref().unwrap_or(&candidate.record.body);
+
+    let cfg = DrainConfig {
+        depth: opts.drain.depth,
+        sim_th: opts.drain.sim_th,
+        max_children: 100,
+        max_clusters: 4,
+        extra_delimiters: opts.drain.extra_delimiters.clone(),
+        ..DrainConfig::default()
+    };
+    let mut engine = Drain::new(cfg);
+    let _ = engine.add_log_message(left);
+    let (cid, is_new) = engine.add_log_message(right);
+    if is_new {
+        return false;
+    }
+
+    let template = engine.clusters().get(&cid).map(|c| c.template()).unwrap_or_default();
+    group.signature = xxh3_64(template.as_bytes());
+    group.drain3_template = Some(template);
+    group.drain3_cluster_id = Some(cid);
+    true
+}

--- a/ljx/src/dedup/dedup_utst.rs
+++ b/ljx/src/dedup/dedup_utst.rs
@@ -344,6 +344,53 @@ fn distinct_merges_far_apart_records_with_intervening_noise() {
 }
 
 #[test]
+fn distinct_canon_merges_small_json_variations_across_services_and_distance() {
+    let batch1 = make_batch(
+        "svc-a",
+        vec![
+            make_log_record(r#"{"requestId":22,"kind":"fake_response","statusCode":299}"#, 9, 100),
+            make_log_record("unrelated placeholder", 9, 150),
+        ],
+    );
+    let batch2 = make_batch("svc-b", vec![make_log_record(r#"{"requestId":23,"kind":"fake_response","statusCode":299}"#, 5, 200)]);
+    let batch3 = make_batch(
+        "svc-c",
+        vec![
+            make_log_record("another unrelated placeholder", 9, 250),
+            make_log_record(r#"{"requestId":24,"kind":"fake_response","statusCode":299}"#, 1, 300),
+        ],
+    );
+    let input = write_logjet(&[batch1, batch2, batch3]);
+    let output = run_dedup(&input, DedupMode::Distinct, DedupMatchMode::Hash2);
+    let groups = read_groups(&output);
+
+    assert_eq!(groups.len(), 3);
+    let merged = groups.iter().find(|(body, _)| body.contains(r#""requestId":22"#)).unwrap();
+    assert_eq!(merged.1, 3);
+}
+
+#[test]
+fn distinct_full_merges_far_apart_freetext_variations_with_noise() {
+    let batch = make_batch(
+        "svc-a",
+        vec![
+            make_log_record("lapsed time is 2", 9, 100),
+            make_log_record("totally different record", 9, 150),
+            make_log_record("lapsed time is 3", 9, 200),
+            make_log_record("another unrelated event", 9, 250),
+            make_log_record("lapsed time is 4", 9, 300),
+        ],
+    );
+    let input = write_logjet(&[batch]);
+    let output = run_dedup(&input, DedupMode::Distinct, DedupMatchMode::Full);
+    let groups = read_groups(&output);
+
+    assert_eq!(groups.len(), 3);
+    let merged = groups.iter().find(|(body, _)| body == "lapsed time is 2").unwrap();
+    assert_eq!(merged.1, 3);
+}
+
+#[test]
 fn collapse_merges_only_consecutive_duplicates() {
     let batch = make_batch(
         "svc-a",

--- a/ljx/src/dedup/dedup_utst.rs
+++ b/ljx/src/dedup/dedup_utst.rs
@@ -123,6 +123,26 @@ fn read_groups(output_bytes: &[u8]) -> Vec<(String, i64)> {
     groups
 }
 
+fn first_log_record(output_bytes: &[u8]) -> LogRecord {
+    let cursor = Cursor::new(output_bytes);
+    let mut reader = LogjetReader::new(cursor);
+    while let Some(rec) = reader.next_record().unwrap() {
+        if rec.record_type != RecordType::Logs {
+            continue;
+        }
+        let batch = ExportLogsServiceRequest::decode(rec.payload.as_slice()).unwrap();
+        return batch.resource_logs[0].scope_logs[0].log_records[0].clone();
+    }
+    panic!("no log record in output");
+}
+
+fn find_attr_str(record: &LogRecord, key: &str) -> Option<String> {
+    record.attributes.iter().find(|a| a.key == key).and_then(|a| match &a.value {
+        Some(AnyValue { value: Some(Value::StringValue(s)) }) => Some(s.clone()),
+        _ => None,
+    })
+}
+
 #[test]
 fn exact_collapses_identical_bodies() {
     let batch = make_batch(
@@ -159,6 +179,18 @@ fn different_severity_stays_separate() {
 }
 
 #[test]
+fn distinct_ignores_severity_boundaries() {
+    let batch1 = make_batch("svc-a", vec![make_log_record("same placeholder", 5, 100)]);
+    let batch2 = make_batch("svc-a", vec![make_log_record("same placeholder", 9, 200)]);
+    let input = write_logjet(&[batch1, batch2]);
+    let output = run_dedup(&input, DedupMode::Distinct, DedupMatchMode::Exact);
+    let groups = read_groups(&output);
+
+    assert_eq!(groups.len(), 1);
+    assert_eq!(groups[0].1, 2);
+}
+
+#[test]
 fn different_service_stays_separate() {
     let batch1 = make_batch("svc-a", vec![make_log_record("same placeholder", 9, 100)]);
     let batch2 = make_batch("svc-b", vec![make_log_record("same placeholder", 9, 200)]);
@@ -168,6 +200,18 @@ fn different_service_stays_separate() {
 
     assert_eq!(groups.len(), 2);
     assert!(groups.iter().all(|(_, c)| *c == 1));
+}
+
+#[test]
+fn distinct_ignores_service_boundaries() {
+    let batch1 = make_batch("svc-a", vec![make_log_record("same placeholder", 9, 100)]);
+    let batch2 = make_batch("svc-b", vec![make_log_record("same placeholder", 9, 200)]);
+    let input = write_logjet(&[batch1, batch2]);
+    let output = run_dedup(&input, DedupMode::Distinct, DedupMatchMode::Exact);
+    let groups = read_groups(&output);
+
+    assert_eq!(groups.len(), 1);
+    assert_eq!(groups[0].1, 2);
 }
 
 #[test]
@@ -276,4 +320,105 @@ fn full_mode_merges_freetext_lines_that_only_change_small_integer() {
 
     assert_eq!(groups.len(), 1);
     assert_eq!(groups[0].1, 4);
+}
+
+#[test]
+fn distinct_merges_far_apart_records_with_intervening_noise() {
+    let batch = make_batch(
+        "svc-a",
+        vec![
+            make_log_record("placeholder route update", 9, 100),
+            make_log_record("totally different record", 9, 200),
+            make_log_record("placeholder route update", 9, 300),
+            make_log_record("another unrelated event", 9, 400),
+            make_log_record("placeholder route update", 9, 500),
+        ],
+    );
+    let input = write_logjet(&[batch]);
+    let output = run_dedup(&input, DedupMode::Distinct, DedupMatchMode::Exact);
+    let groups = read_groups(&output);
+
+    assert_eq!(groups.len(), 3);
+    let repeated = groups.iter().find(|(body, _)| body == "placeholder route update").unwrap();
+    assert_eq!(repeated.1, 3);
+}
+
+#[test]
+fn collapse_merges_only_consecutive_duplicates() {
+    let batch = make_batch(
+        "svc-a",
+        vec![
+            make_log_record("placeholder route update", 9, 100),
+            make_log_record("placeholder route update", 9, 200),
+            make_log_record("different record", 9, 300),
+        ],
+    );
+    let input = write_logjet(&[batch]);
+    let output = run_dedup(&input, DedupMode::Collapse, DedupMatchMode::Exact);
+    let groups = read_groups(&output);
+
+    assert_eq!(groups.len(), 2);
+    let repeated = groups.iter().find(|(body, _)| body == "placeholder route update").unwrap();
+    assert_eq!(repeated.1, 2);
+}
+
+#[test]
+fn collapse_keeps_far_apart_duplicates_as_separate_groups() {
+    let batch = make_batch(
+        "svc-a",
+        vec![
+            make_log_record("placeholder route update", 9, 100),
+            make_log_record("different record", 9, 200),
+            make_log_record("placeholder route update", 9, 300),
+        ],
+    );
+    let input = write_logjet(&[batch]);
+    let output = run_dedup(&input, DedupMode::Collapse, DedupMatchMode::Exact);
+    let groups = read_groups(&output);
+
+    assert_eq!(groups.len(), 3);
+    let repeated_count = groups.iter().filter(|(body, count)| body == "placeholder route update" && *count == 1).count();
+    assert_eq!(repeated_count, 2);
+}
+
+#[test]
+fn collapse_full_merges_consecutive_freetext_burst() {
+    let batch = make_batch(
+        "svc-a",
+        vec![make_log_record("lapsed time is 2", 9, 100), make_log_record("lapsed time is 3", 9, 200), make_log_record("lapsed time is 4", 9, 300)],
+    );
+    let input = write_logjet(&[batch]);
+    let output = run_dedup(&input, DedupMode::Collapse, DedupMatchMode::Full);
+    let groups = read_groups(&output);
+
+    assert_eq!(groups.len(), 1);
+    assert_eq!(groups[0].1, 3);
+}
+
+#[test]
+fn distinct_metadata_is_explicit() {
+    let batch = make_batch("svc-a", vec![make_log_record("placeholder route update", 9, 100), make_log_record("placeholder route update", 9, 200)]);
+    let input = write_logjet(&[batch]);
+    let output = run_dedup(&input, DedupMode::Distinct, DedupMatchMode::Exact);
+    let record = first_log_record(&output);
+
+    assert_eq!(find_attr_str(&record, "dedup.mode").as_deref(), Some("distinct/exact"));
+    assert_eq!(find_attr_str(&record, "dedup.behaviour").as_deref(), Some("distinct"));
+    assert_eq!(find_attr_str(&record, "dedup.matcher").as_deref(), Some("exact"));
+    assert_eq!(find_attr_str(&record, "dedup.scope").as_deref(), Some("global"));
+    assert_eq!(find_attr_str(&record, "dedup.window").as_deref(), Some("whole-selection"));
+}
+
+#[test]
+fn collapse_metadata_describes_burst_mode() {
+    let batch = make_batch("svc-a", vec![make_log_record("lapsed time is 2", 9, 100), make_log_record("lapsed time is 3", 9, 200)]);
+    let input = write_logjet(&[batch]);
+    let output = run_dedup(&input, DedupMode::Collapse, DedupMatchMode::Full);
+    let record = first_log_record(&output);
+
+    assert_eq!(find_attr_str(&record, "dedup.mode").as_deref(), Some("collapse/drain3"));
+    assert_eq!(find_attr_str(&record, "dedup.behaviour").as_deref(), Some("collapse"));
+    assert_eq!(find_attr_str(&record, "dedup.matcher").as_deref(), Some("drain3"));
+    assert_eq!(find_attr_str(&record, "dedup.scope").as_deref(), Some("bucketed"));
+    assert_eq!(find_attr_str(&record, "dedup.window").as_deref(), Some("consecutive-run"));
 }

--- a/ljx/src/dedup/dedup_utst.rs
+++ b/ljx/src/dedup/dedup_utst.rs
@@ -1,4 +1,4 @@
-//! Integration tests for the dedup pipeline (exact mode).
+//! Integration tests for the dedup pipeline.
 
 use std::io::Cursor;
 

--- a/ljx/src/dedup/dedup_utst.rs
+++ b/ljx/src/dedup/dedup_utst.rs
@@ -11,7 +11,7 @@ use opentelemetry_proto::tonic::resource::v1::Resource;
 use prost::Message;
 
 use crate::dedup::flat_record::BucketKeyKind;
-use crate::dedup::{DedupMode, DedupOpts};
+use crate::dedup::{DedupMatchMode, DedupMode, DedupOpts};
 
 fn make_log_record(body: &str, severity: i32, time_ns: u64) -> LogRecord {
     LogRecord {
@@ -71,15 +71,15 @@ fn write_logjet(batches: &[ExportLogsServiceRequest]) -> Vec<u8> {
     buf
 }
 
-/// Run exact-mode dedup on raw logjet bytes, return output bytes.
-fn run_dedup(input_bytes: &[u8], mode: DedupMode) -> Vec<u8> {
+/// Run dedup on raw logjet bytes, return output bytes.
+fn run_dedup(input_bytes: &[u8], behavior: DedupMode, match_mode: DedupMatchMode) -> Vec<u8> {
     let cursor = Cursor::new(input_bytes);
     let mut reader = LogjetReader::new(cursor);
     let unpacked = crate::dedup::unpack::unpack(&mut reader).unwrap();
 
     let mut out_buf = Vec::new();
     let mut writer = LogjetWriter::new(Cursor::new(&mut out_buf));
-    let opts = DedupOpts { mode, bucket_key: BucketKeyKind::Default, drain: Default::default() };
+    let opts = DedupOpts { mode: behavior, match_mode, bucket_key: BucketKeyKind::Default, drain: Default::default() };
     let _stats = crate::dedup::dedup(unpacked.records, unpacked.passthrough, &mut writer, &opts).unwrap();
     writer.into_inner().unwrap();
     out_buf
@@ -135,7 +135,7 @@ fn exact_collapses_identical_bodies() {
         ],
     );
     let input = write_logjet(&[batch]);
-    let output = run_dedup(&input, DedupMode::Exact);
+    let output = run_dedup(&input, DedupMode::Distinct, DedupMatchMode::Exact);
     let groups = read_groups(&output);
 
     assert_eq!(groups.len(), 2);
@@ -150,7 +150,7 @@ fn different_severity_stays_separate() {
     let batch1 = make_batch("svc-a", vec![make_log_record("same placeholder", 5, 100)]);
     let batch2 = make_batch("svc-a", vec![make_log_record("same placeholder", 9, 200)]);
     let input = write_logjet(&[batch1, batch2]);
-    let output = run_dedup(&input, DedupMode::Exact);
+    let output = run_dedup(&input, DedupMode::Collapse, DedupMatchMode::Exact);
     let groups = read_groups(&output);
 
     // Same body but different severity → different buckets → 2 groups.
@@ -163,7 +163,7 @@ fn different_service_stays_separate() {
     let batch1 = make_batch("svc-a", vec![make_log_record("same placeholder", 9, 100)]);
     let batch2 = make_batch("svc-b", vec![make_log_record("same placeholder", 9, 200)]);
     let input = write_logjet(&[batch1, batch2]);
-    let output = run_dedup(&input, DedupMode::Exact);
+    let output = run_dedup(&input, DedupMode::Collapse, DedupMatchMode::Exact);
     let groups = read_groups(&output);
 
     assert_eq!(groups.len(), 2);
@@ -177,7 +177,7 @@ fn timestamps_first_and_last_correct() {
         vec![make_log_record("placeholder", 9, 500), make_log_record("placeholder", 9, 100), make_log_record("placeholder", 9, 900)],
     );
     let input = write_logjet(&[batch]);
-    let output = run_dedup(&input, DedupMode::Exact);
+    let output = run_dedup(&input, DedupMode::Distinct, DedupMatchMode::Exact);
 
     let cursor = Cursor::new(&output);
     let mut reader = LogjetReader::new(cursor);
@@ -212,7 +212,7 @@ fn passthrough_non_log_records() {
         writer.into_inner().unwrap();
     }
 
-    let output = run_dedup(&buf, DedupMode::Exact);
+    let output = run_dedup(&buf, DedupMode::Distinct, DedupMatchMode::Exact);
 
     // Should have 2 records out: 1 deduped log + 1 passthrough metrics.
     let cursor = Cursor::new(&output);
@@ -233,7 +233,7 @@ fn passthrough_non_log_records() {
 #[test]
 fn empty_input_produces_empty_output() {
     let input = write_logjet(&[]);
-    let output = run_dedup(&input, DedupMode::Exact);
+    let output = run_dedup(&input, DedupMode::Distinct, DedupMatchMode::Exact);
     let groups = read_groups(&output);
     assert!(groups.is_empty());
 }
@@ -252,7 +252,7 @@ fn full_mode_runs_drain3_for_small_residual_sets() {
         vec![make_log_record("error in section alpha at line 42", 9, 100), make_log_record("error in section beta at line 99", 9, 200)],
     );
     let input = write_logjet(&[batch]);
-    let output = run_dedup(&input, DedupMode::Full);
+    let output = run_dedup(&input, DedupMode::Distinct, DedupMatchMode::Full);
     let groups = read_groups(&output);
 
     assert_eq!(groups.len(), 1);
@@ -271,7 +271,7 @@ fn full_mode_merges_freetext_lines_that_only_change_small_integer() {
         ],
     );
     let input = write_logjet(&[batch]);
-    let output = run_dedup(&input, DedupMode::Full);
+    let output = run_dedup(&input, DedupMode::Distinct, DedupMatchMode::Full);
     let groups = read_groups(&output);
 
     assert_eq!(groups.len(), 1);

--- a/ljx/src/dedup/dedup_utst.rs
+++ b/ljx/src/dedup/dedup_utst.rs
@@ -429,6 +429,42 @@ fn collapse_keeps_far_apart_duplicates_as_separate_groups() {
 }
 
 #[test]
+fn collapse_preserves_bucket_boundaries_inside_a_burst() {
+    let batch1 = make_batch("svc-a", vec![make_log_record("placeholder route update", 9, 100)]);
+    let batch2 = make_batch("svc-b", vec![make_log_record("placeholder route update", 9, 200)]);
+    let input = write_logjet(&[batch1, batch2]);
+    let output = run_dedup(&input, DedupMode::Collapse, DedupMatchMode::Exact);
+    let groups = read_groups(&output);
+
+    assert_eq!(groups.len(), 2);
+    assert!(groups.iter().all(|(_, count)| *count == 1));
+}
+
+#[test]
+fn collapse_does_not_merge_alternating_messages_into_one_group() {
+    let batch = make_batch(
+        "svc-a",
+        vec![
+            make_log_record("placeholder route update", 9, 100),
+            make_log_record("placeholder route update", 9, 200),
+            make_log_record("different placeholder", 9, 300),
+            make_log_record("different placeholder", 9, 400),
+            make_log_record("placeholder route update", 9, 500),
+            make_log_record("placeholder route update", 9, 600),
+        ],
+    );
+    let input = write_logjet(&[batch]);
+    let output = run_dedup(&input, DedupMode::Collapse, DedupMatchMode::Exact);
+    let groups = read_groups(&output);
+
+    assert_eq!(groups.len(), 3);
+    let repeated_runs = groups.iter().filter(|(body, count)| body == "placeholder route update" && *count == 2).count();
+    assert_eq!(repeated_runs, 2);
+    let different = groups.iter().find(|(body, _)| body == "different placeholder").unwrap();
+    assert_eq!(different.1, 2);
+}
+
+#[test]
 fn collapse_full_merges_consecutive_freetext_burst() {
     let batch = make_batch(
         "svc-a",

--- a/ljx/src/dedup/detect.rs
+++ b/ljx/src/dedup/detect.rs
@@ -35,9 +35,9 @@ pub struct Detected {
 
 /// Detect the body shape of a log line.
 pub fn detect(body: &str) -> Detected {
-    // JSON: starts with '{"' or '[{' or '[[', and parses successfully.
+    // JSON: starts with an object/array opener and parses successfully.
     let trimmed = body.trim_start();
-    if (trimmed.starts_with("{\"") || trimmed.starts_with("[{") || trimmed.starts_with("[["))
+    if (trimmed.starts_with('{') || trimmed.starts_with('['))
         && let Ok(val) = serde_json::from_str::<Value>(trimmed)
     {
         return Detected { shape: BodyShape::Json, json_value: Some(val), stripped_suffix: None };
@@ -84,9 +84,7 @@ fn strip_source_prefix(body: &str) -> Option<String> {
 /// Strip any non-JSON prefix before a valid JSON object/array suffix.
 fn strip_json_prefix(body: &str) -> Option<String> {
     let trimmed = body.trim_start();
-    if trimmed.starts_with('{') {
-        return None;
-    }
+    let trimmed_start = body.len() - trimmed.len();
 
     for (idx, ch) in body.char_indices() {
         if !matches!(ch, '{' | '[') {
@@ -94,6 +92,9 @@ fn strip_json_prefix(body: &str) -> Option<String> {
         }
         let suffix = body[idx..].trim_start();
         if !(suffix.starts_with('{') || suffix.starts_with('[')) {
+            continue;
+        }
+        if idx == trimmed_start {
             continue;
         }
         if serde_json::from_str::<Value>(suffix).is_ok() {

--- a/ljx/src/dedup/detect_utst.rs
+++ b/ljx/src/dedup/detect_utst.rs
@@ -15,6 +15,14 @@ fn json_array() {
 }
 
 #[test]
+fn json_scalar_array_is_json_not_prefixed() {
+    let d = detect(r#"[1,2,3]"#);
+    assert_eq!(d.shape, BodyShape::Json);
+    assert!(d.json_value.is_some());
+    assert!(d.stripped_suffix.is_none());
+}
+
+#[test]
 fn json_with_leading_whitespace() {
     let d = detect(r#"  {"fake_key":"fake_value"}"#);
     assert_eq!(d.shape, BodyShape::Json);

--- a/ljx/src/dedup/emit.rs
+++ b/ljx/src/dedup/emit.rs
@@ -48,17 +48,15 @@ pub fn write<W: Write>(writer: &mut LogjetWriter<W>, groups: &[DedupGroup], pass
 fn build_otlp_payload(group: &DedupGroup, mode_label: &str) -> Vec<u8> {
     let rep = &group.representative;
     let sig_hex = format!("{:016x}", group.signature);
+    let meta = dedup_metadata(mode_label, group.drain3_template.is_some());
 
     let mut attrs = rep.record_attrs.clone();
     push_attr_i64(&mut attrs, "dedup.count", group.count as i64);
-    let effective_mode = if group.drain3_template.is_some() {
-        "full/drain3"
-    } else if mode_label == "full" {
-        "full/canon"
-    } else {
-        mode_label
-    };
-    push_attr_str(&mut attrs, "dedup.mode", effective_mode);
+    push_attr_str(&mut attrs, "dedup.mode", &meta.effective_mode);
+    push_attr_str(&mut attrs, "dedup.behaviour", meta.behaviour);
+    push_attr_str(&mut attrs, "dedup.matcher", meta.matcher);
+    push_attr_str(&mut attrs, "dedup.scope", meta.scope);
+    push_attr_str(&mut attrs, "dedup.window", meta.window);
     push_attr_str(&mut attrs, "dedup.signature", &sig_hex);
     push_attr_i64(&mut attrs, "dedup.first_seen_ns", group.first_seen_ns as i64);
     push_attr_i64(&mut attrs, "dedup.last_seen_ns", group.last_seen_ns as i64);
@@ -109,6 +107,38 @@ fn build_otlp_payload(group: &DedupGroup, mode_label: &str) -> Vec<u8> {
         }],
     };
     batch.encode_to_vec()
+}
+
+struct DedupMetadata<'a> {
+    effective_mode: String,
+    behaviour: &'a str,
+    matcher: &'a str,
+    scope: &'a str,
+    window: &'a str,
+}
+
+fn dedup_metadata(mode_label: &str, used_drain3: bool) -> DedupMetadata<'_> {
+    let (behaviour, base_matcher) = mode_label.split_once('/').unwrap_or((mode_label, "exact"));
+    let matcher = if used_drain3 && base_matcher == "full" {
+        "drain3"
+    } else if base_matcher == "full" {
+        "canon"
+    } else {
+        base_matcher
+    };
+    let effective_mode = format!("{behaviour}/{matcher}");
+    let scope = match behaviour {
+        "distinct" => "global",
+        "collapse" => "bucketed",
+        _ => "unknown",
+    };
+    let window = match behaviour {
+        "distinct" => "whole-selection",
+        "collapse" => "consecutive-run",
+        _ => "unknown",
+    };
+
+    DedupMetadata { effective_mode, behaviour, matcher, scope, window }
 }
 
 fn push_attr_str(attrs: &mut Vec<KeyValue>, key: &str, val: &str) {

--- a/ljx/src/dedup/flat_record.rs
+++ b/ljx/src/dedup/flat_record.rs
@@ -7,6 +7,8 @@
 /// Selects which fields form the bucket key for dedup grouping.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BucketKeyKind {
+    /// Global: ignore bucket boundaries entirely.
+    Global,
     /// Default: (service_name, severity_number).
     Default,
     /// Adds instrumentation scope name.
@@ -37,7 +39,12 @@ impl BucketKey {
             BucketKeyKind::SourceLine | BucketKeyKind::ScopeAndSourceLine => (rec.code_filepath.clone(), rec.code_lineno),
             _ => (None, None),
         };
-        Self { service_name: rec.service_name.clone(), severity_number: rec.severity_number, scope_name, code_filepath, code_lineno }
+        match kind {
+            BucketKeyKind::Global => {
+                Self { service_name: String::new(), severity_number: 0, scope_name: None, code_filepath: None, code_lineno: None }
+            }
+            _ => Self { service_name: rec.service_name.clone(), severity_number: rec.severity_number, scope_name, code_filepath, code_lineno },
+        }
     }
 }
 

--- a/ljx/src/dedup/mod.rs
+++ b/ljx/src/dedup/mod.rs
@@ -63,7 +63,6 @@ use flat_record::{BucketKey, BucketKeyKind, FlatRecord};
 pub enum DedupMode {
     /// Collapse duplicates across the whole selected dataset.
     Distinct,
-    #[allow(dead_code)]
     /// Collapse duplicates only in a local burst / nearby sense.
     Collapse,
 }

--- a/ljx/src/dedup/mod.rs
+++ b/ljx/src/dedup/mod.rs
@@ -48,6 +48,7 @@ pub mod canon;
 pub mod canon_freetext;
 pub mod canon_json;
 pub mod canon_kv;
+pub mod collapse;
 pub mod detect;
 pub mod drain3;
 pub mod emit;
@@ -242,16 +243,19 @@ impl DedupStats {
 pub fn dedup(
     records: Vec<FlatRecord>, passthrough: Vec<logjet::OwnedRecord>, output: &mut logjet::LogjetWriter<impl std::io::Write>, opts: &DedupOpts,
 ) -> crate::error::Result<DedupStats> {
-    let bucket_key = match opts.mode.bucket_policy() {
-        DedupBucketPolicy::Global => BucketKeyKind::Global,
-        DedupBucketPolicy::Requested => opts.bucket_key,
+    let groups = match opts.mode {
+        DedupMode::Distinct => {
+            let bucket_key = match opts.mode.bucket_policy() {
+                DedupBucketPolicy::Global => BucketKeyKind::Global,
+                DedupBucketPolicy::Requested => opts.bucket_key,
+            };
+            let buckets = bucket::group(records, bucket_key);
+            let groups = exact::dedup(buckets);
+            let groups = if opts.match_mode >= DedupMatchMode::Hash2 { canon::canon_dedup(groups) } else { groups };
+            if opts.match_mode >= DedupMatchMode::Full { dedup_residuals(groups, &opts.drain) } else { groups }
+        }
+        DedupMode::Collapse => collapse::dedup(records, opts),
     };
-    let buckets = bucket::group(records, bucket_key);
-    let groups = exact::dedup(buckets);
-
-    let groups = if opts.match_mode >= DedupMatchMode::Hash2 { canon::canon_dedup(groups) } else { groups };
-
-    let groups = if opts.match_mode >= DedupMatchMode::Full { dedup_residuals(groups, &opts.drain) } else { groups };
 
     let mode_label = match (opts.mode, opts.match_mode) {
         (DedupMode::Distinct, DedupMatchMode::Exact) => "distinct/exact",

--- a/ljx/src/dedup/mod.rs
+++ b/ljx/src/dedup/mod.rs
@@ -2,6 +2,46 @@
 //!
 //! OTel-native: unpack → bucket → exact → (canon) → (drain) → emit.
 //! Stages in parentheses are only active in hash2/full modes.
+//!
+//! Dedup semantics note
+//! --------------------
+//!
+//! We want to expose two user-facing dedup behaviours:
+//!
+//! 1. `distinct`
+//!    Collapse duplicate records across the whole selected dataset.
+//!    Record order does not matter. If the same message shape appears at
+//!    the start and the end of the file, it should still become one group.
+//!
+//! 2. `collapse`
+//!    Collapse repeated records only in a local burst / nearby sense.
+//!    The same message may reappear later as a new group after the burst
+//!    has ended.
+//!
+//! These behaviour modes are separate from the matching stack. The
+//! matching stack stays:
+//!
+//! - exact body equality
+//! - canonicalisation (`canon`)
+//! - optional Drain3 fallback on remaining residuals
+//!
+//! In other words, `distinct` is not byte-for-byte SQL `DISTINCT` over the
+//! original body string. It is "distinct over the dedup signature" after
+//! the selected normalisation stages have run.
+//!
+//! Frozen decisions for the first implementation:
+//!
+//! - `distinct` is whole-selection, not adjacency-based.
+//! - `distinct` is global by default: it should ignore current
+//!   service/severity bucket boundaries unless a later explicit override is
+//!   introduced.
+//! - `collapse` is local/burst-oriented and should keep conservative safety
+//!   boundaries such as service/severity unless we later add a looser mode.
+//! - both behaviours may use canon and Drain3; the difference is scope, not
+//!   whether normalisation exists.
+//! - emitted metadata should make both behaviour and matcher visible, for
+//!   example `distinct/canon`, `distinct/drain3`, `collapse/canon`, or
+//!   `collapse/drain3`.
 
 pub mod bucket;
 pub mod canon;
@@ -17,9 +57,37 @@ pub mod unpack;
 
 use flat_record::{BucketKey, BucketKeyKind, FlatRecord};
 
-/// Deduplication aggressiveness.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+/// User-facing dedup behaviour.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DedupMode {
+    /// Collapse duplicates across the whole selected dataset.
+    Distinct,
+    /// Collapse duplicates only in a local burst / nearby sense.
+    Collapse,
+}
+
+/// Bucket policy implied by the user-facing dedup behaviour.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DedupBucketPolicy {
+    /// Ignore service/severity bucket boundaries and group globally.
+    Global,
+    /// Respect the configured bucket key.
+    Requested,
+}
+
+impl DedupMode {
+    /// Frozen bucket policy for the first implementation.
+    pub fn bucket_policy(self) -> DedupBucketPolicy {
+        match self {
+            Self::Distinct => DedupBucketPolicy::Global,
+            Self::Collapse => DedupBucketPolicy::Requested,
+        }
+    }
+}
+
+/// Matching aggressiveness inside the selected dedup behaviour.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum DedupMatchMode {
     /// Stage 2 only: collapse byte-identical bodies.
     Exact,
     /// Stages 2 + 3: canonicalise then hash.
@@ -32,6 +100,7 @@ pub enum DedupMode {
 #[derive(Debug, Clone)]
 pub struct DedupOpts {
     pub mode: DedupMode,
+    pub match_mode: DedupMatchMode,
     pub bucket_key: BucketKeyKind,
     pub drain: DrainOpts,
 }
@@ -52,7 +121,7 @@ impl Default for DrainOpts {
 
 impl Default for DedupOpts {
     fn default() -> Self {
-        Self { mode: DedupMode::Hash2, bucket_key: BucketKeyKind::Default, drain: DrainOpts::default() }
+        Self { mode: DedupMode::Distinct, match_mode: DedupMatchMode::Hash2, bucket_key: BucketKeyKind::Default, drain: DrainOpts::default() }
     }
 }
 
@@ -173,17 +242,24 @@ impl DedupStats {
 pub fn dedup(
     records: Vec<FlatRecord>, passthrough: Vec<logjet::OwnedRecord>, output: &mut logjet::LogjetWriter<impl std::io::Write>, opts: &DedupOpts,
 ) -> crate::error::Result<DedupStats> {
-    let buckets = bucket::group(records, opts.bucket_key);
+    let bucket_key = match opts.mode.bucket_policy() {
+        DedupBucketPolicy::Global => BucketKeyKind::Global,
+        DedupBucketPolicy::Requested => opts.bucket_key,
+    };
+    let buckets = bucket::group(records, bucket_key);
     let groups = exact::dedup(buckets);
 
-    let groups = if opts.mode >= DedupMode::Hash2 { canon::canon_dedup(groups) } else { groups };
+    let groups = if opts.match_mode >= DedupMatchMode::Hash2 { canon::canon_dedup(groups) } else { groups };
 
-    let groups = if opts.mode >= DedupMode::Full { dedup_residuals(groups, &opts.drain) } else { groups };
+    let groups = if opts.match_mode >= DedupMatchMode::Full { dedup_residuals(groups, &opts.drain) } else { groups };
 
-    let mode_label = match opts.mode {
-        DedupMode::Exact => "exact",
-        DedupMode::Hash2 => "hash2",
-        DedupMode::Full => "full",
+    let mode_label = match (opts.mode, opts.match_mode) {
+        (DedupMode::Distinct, DedupMatchMode::Exact) => "distinct/exact",
+        (DedupMode::Distinct, DedupMatchMode::Hash2) => "distinct/canon",
+        (DedupMode::Distinct, DedupMatchMode::Full) => "distinct/full",
+        (DedupMode::Collapse, DedupMatchMode::Exact) => "collapse/exact",
+        (DedupMode::Collapse, DedupMatchMode::Hash2) => "collapse/canon",
+        (DedupMode::Collapse, DedupMatchMode::Full) => "collapse/full",
     };
 
     emit::write(output, &groups, &passthrough, mode_label)

--- a/ljx/src/dedup/mod.rs
+++ b/ljx/src/dedup/mod.rs
@@ -63,6 +63,7 @@ use flat_record::{BucketKey, BucketKeyKind, FlatRecord};
 pub enum DedupMode {
     /// Collapse duplicates across the whole selected dataset.
     Distinct,
+    #[allow(dead_code)]
     /// Collapse duplicates only in a local burst / nearby sense.
     Collapse,
 }


### PR DESCRIPTION
Current dedup works in old-school syslong mode: collapse only nearby entries, which results to still have the similar messages _after_ deduplication. Especially if filtered-out by severity or service.

Global mode should be similar to DB's `distinct` SQL keyword per entire logfile.