### PR TITLE
Add CLI query

### DIFF
--- a/doc/ljx.md
+++ b/doc/ljx.md
@@ -31,6 +31,7 @@ Core goals:
 
 Documented command set:
 
+- top-level query/export mode
 - `count`
 - `filter`
 - `stats`
@@ -65,6 +66,45 @@ why. If stdin is later supported by spooling to a temporary file, that behaviour
 should be documented as an explicit implementation choice.
 
 ## Command Intent
+
+## `ljx <input>`
+
+Stream one `.logjet` input as NDJSON to stdout.
+
+This is the fast path for shell pipelines and ad hoc inspection when the TUI is
+too heavy and rewriting another `.logjet` file is not what you want.
+
+Examples:
+
+```text
+ljx telemetry.logjet
+ljx telemetry.logjet -F error -i
+ljx telemetry.logjet -F error -e 'customer-123|customer-456' -i
+ljx telemetry.logjet --fields body,timestamp,service_name
+```
+
+Current behaviour:
+
+- default output format is `ndjson`
+- output goes to stdout
+- predicates are the same as `count` and `filter`
+- `--fields` limits NDJSON keys without changing match semantics
+
+For OTLP log records, NDJSON output includes the core record fields when
+present, including:
+
+- `body`
+- `timestamp`
+- `observed_timestamp`
+- `severity_text`
+- `severity_number`
+- `event_name`
+- `trace_id`
+- `span_id`
+- `flags`
+- `scope_name`
+- `scope_version`
+- flattened resource, scope, and record attributes such as `service_name`
 
 ## `ljx count`
 
@@ -112,7 +152,24 @@ Supported payload matching modes:
 - `-e`, `--grep` for grep-style regex matching
 - `-i`, `--ignore-case` to make either payload matcher case-insensitive
 
-`ljx` uses one payload matcher at a time. `-F` and `-e` are mutually exclusive.
+Payload matchers are repeatable and combined with logical AND:
+
+- repeated `-F` means every literal must match
+- repeated `-e` means every regex must match
+- `-F` and `-e` can be mixed, and all matchers must pass
+
+Examples:
+
+```text
+ljx telemetry.logjet -F error -F customer-123
+ljx telemetry.logjet -e 'timeout|deadline exceeded' -e 'customer-123|customer-456'
+ljx telemetry.logjet -F error -e 'panic|fatal' -i
+```
+
+Within one `-e`, normal regex alternation still applies, so:
+
+- `-e 'foo|bar'` means one regex matcher that accepts either term
+- `-e foo -e bar` means both regexes must match somewhere in the payload
 
 ## `ljx stats`
 
@@ -236,6 +293,7 @@ Important behaviour:
 - export is streaming and preserves input record order
 - the host owns the output file and passes bytes through callbacks to the plugin
 - if the output file already exists, `--force` is required to overwrite it
+- `--fields` is supported only for `ndjson` export and limits the exported JSON keys
 - plugin discovery order and ABI rules are documented in `doc/parquet/exporters-abi.md`
 - Parquet-specific usage, schema, installation, and limits are documented in
   `doc/parquet/export-parquet.md`

--- a/doc/manpage/ljx.1.md
+++ b/doc/manpage/ljx.1.md
@@ -8,6 +8,8 @@ ljx - offline toolbox for inspecting and transforming `.logjet` files
 
 # SYNOPSIS
 
+`ljx` *input* [`--format` *format*] [`--fields` *key[,key...]*] [*predicate-options*]
+
 `ljx` `count` *input* [*predicate-options*]
 
 `ljx` `filter` *input* `-o` *output* [*predicate-options*] [`--codec` *codec*] [`--block-target-size` *bytes*]
@@ -133,7 +135,31 @@ Expected options:
 - `-F`, `--fixed-string` *text*
 - `-i`, `--ignore-case`
 
-`-e` and `-F` are mutually exclusive.
+Payload matchers are repeatable and combined with logical AND.
+
+- repeat `-F` to require multiple literal substrings
+- repeat `-e` to require multiple regex matches
+- mix `-F` and `-e` to require both literal and regex matches
+
+Within one `-e`, ordinary regex alternation still applies, so
+`-e 'foo|bar'` means one matcher that accepts either term.
+
+## Top-level NDJSON query options
+
+## `--format` *ndjson*
+
+Select the output format for top-level `ljx` *input* mode.
+
+Current top-level query mode supports `ndjson` and defaults to it.
+
+## `--fields` *key[,key...]* 
+
+Limit NDJSON output to selected JSON keys.
+
+Repeat the flag or use comma-separated values to accumulate keys.
+When omitted, all exported keys are written.
+
+`--fields` only applies to NDJSON output.
 
 ## Filter output options
 
@@ -201,6 +227,23 @@ ljx filter telemetry.logjet -o copy.logjet
 
 Use this for a straight record-aware rewrite.
 
+## 5b. Stream NDJSON to stdout
+
+```text
+ljx telemetry.logjet
+```
+
+Use this for quick terminal inspection or shell pipelines without starting the
+interactive TUI.
+
+## 5c. Stream only selected JSON keys
+
+```text
+ljx telemetry.logjet --fields body,timestamp,service_name
+```
+
+Use this when full OTLP-derived rows are too verbose for terminal work.
+
 ## 5a. Keep records containing a literal string
 
 ```text
@@ -233,7 +276,7 @@ ljx filter telemetry.logjet -o one-hour.logjet --ts-min 1700000000000000000 --ts
 
 Use this to extract a specific time window into a new `.logjet` file.
 
-## 9. Stream filtered output to stdout
+## 9. Stream filtered `.logjet` output to stdout
 
 ```text
 ljx filter telemetry.logjet -o - --type logs > only-logs.logjet
@@ -262,6 +305,16 @@ There are two user-facing modes:
 - `-e`, `--grep` for grep-style regex search
 
 Case-insensitive matching is enabled with `-i`, `--ignore-case`.
+
+Matchers can be repeated and are combined with AND semantics.
+
+Examples:
+
+```text
+ljx telemetry.logjet -F error -F customer-123
+ljx telemetry.logjet -e 'timeout|deadline exceeded' -e customer-123
+ljx telemetry.logjet -F error -e 'panic|fatal' -i
+```
 
 ## 12. Regex payload match: wildcard in the middle
 
@@ -294,6 +347,15 @@ ljx view telemetry.logjet
 ```
 
 Use this when you want a human-readable record listing.
+
+## 15a. Print NDJSON records for terminal inspection
+
+```text
+ljx telemetry.logjet -F error -i
+```
+
+Use this when you want structured records on stdout rather than the interactive
+TUI.
 
 ## 16. Print records with hex payload rendering
 

--- a/ljx/src/cli.rs
+++ b/ljx/src/cli.rs
@@ -26,14 +26,28 @@ pub struct Cli {
     )]
     pub export: Option<String>,
 
+    #[arg(long, value_enum, value_name = "FORMAT", requires = "input", help = "Output format for top-level query mode")]
+    pub format: Option<ExportFormat>,
+
+    #[arg(
+        long,
+        value_name = "KEY[,KEY...]",
+        value_delimiter = ',',
+        help = "Limit NDJSON output to selected JSON keys; repeat or comma-separate keys"
+    )]
+    pub fields: Vec<String>,
+
     #[arg(short, long, value_name = "OUTPUT", requires = "export", help = "Output file or - for stdout")]
     pub output: Option<PathBuf>,
 
     #[arg(long = "force", requires = "export", help = "Overwrite output file if it already exists")]
     pub force: bool,
 
-    #[arg(value_name = "INPUT", requires = "export", help = "Input .logjet file or - for stdin")]
+    #[arg(value_name = "INPUT", help = "Input .logjet file or - for stdin")]
     pub input: Option<PathBuf>,
+
+    #[command(flatten)]
+    pub predicate: PredicateArgs,
 
     #[command(subcommand)]
     pub command: Option<Command>,
@@ -51,13 +65,14 @@ pub fn build_cli() -> clap::Command {
         .usage(styling::AnsiColor::Yellow.on_default())
         .literal(styling::AnsiColor::BrightGreen.on_default())
         .placeholder(styling::AnsiColor::BrightMagenta.on_default());
-    let after_help = "Examples:\n  ljx count telemetry.logjet -F error -i\n  ljx filter telemetry.logjet -o only-logs.logjet -e 'java\\..*\\.bs'\n  ljx view telemetry.logjet\n  ljx --export ndjson telemetry.logjet -o telemetry.ndjson\n  ljx --export parquet telemetry.logjet -o telemetry.parquet --force";
+    let after_help = "Examples:\n  ljx telemetry.logjet\n  ljx telemetry.logjet -F error -i\n  ljx telemetry.logjet --fields body,timestamp,service_name -F error\n  ljx telemetry.logjet -e 'java\\..*\\.bs'\n  ljx count telemetry.logjet -F error -i\n  ljx filter telemetry.logjet -o only-logs.logjet -e 'java\\..*\\.bs'\n  ljx view telemetry.logjet\n  ljx --export ndjson telemetry.logjet -o telemetry.ndjson --fields body,timestamp\n  ljx --export parquet telemetry.logjet -o telemetry.parquet --force";
 
     Cli::command()
-        .arg_required_else_help(true)
         .styles(styles)
         .about(format!("{} - {}", appname.bright_magenta().bold(), "offline toolbox for .logjet streams"))
-        .override_usage(format!("{appname} <COMMAND> [OPTIONS] [ARGS]\n  {appname} --export <FORMAT> <INPUT> -o <OUTPUT> [--force]"))
+        .override_usage(format!(
+            "{appname} <INPUT> [--format <FORMAT>] [FILTER OPTIONS]\n  {appname} <COMMAND> [OPTIONS] [ARGS]\n  {appname} --export <FORMAT> <INPUT> -o <OUTPUT> [--force]"
+        ))
         .mut_arg("export", |arg| arg.help(&export_help).long_help(&export_help))
         .after_help(after_help)
 }

--- a/ljx/src/commands/export.rs
+++ b/ljx/src/commands/export.rs
@@ -11,18 +11,23 @@ use logjet::{LogjetReader, OwnedRecord, RecordType};
 use opentelemetry_proto::tonic::collector::logs::v1::ExportLogsServiceRequest;
 use opentelemetry_proto::tonic::common::v1::AnyValue;
 use opentelemetry_proto::tonic::common::v1::any_value::Value;
+use opentelemetry_proto::tonic::logs::v1::LogRecord;
 use prost::Message;
 use serde_json::{Map as JsonMap, Value as JsonValue};
 
 use crate::error::{Error, Result};
 use crate::exporter::ExporterRegistry;
 use crate::input::{InputHandle, open_output_with_policy};
+use crate::predicate::RecordPredicate;
 
 /// Run the top-level export flow for one input file.
-pub fn run(format: &str, input: &Path, output: &Path, force: bool) -> Result<()> {
+pub fn run(format: &str, input: &Path, output: &Path, force: bool, fields: &[String]) -> Result<()> {
     match format {
-        "ndjson" => run_ndjson(input, output, force),
+        "ndjson" => run_ndjson(input, output, force, fields),
         other => {
+            if !fields.is_empty() {
+                return Err(Error::Usage(format!("--fields is only supported with ndjson output, not {other}")));
+            }
             let registry = ExporterRegistry::discover();
             let Some(plugin) = registry.plugin(other) else {
                 return Err(registry.unknown_format_error(other));
@@ -32,13 +37,16 @@ pub fn run(format: &str, input: &Path, output: &Path, force: bool) -> Result<()>
     }
 }
 
-fn run_ndjson(input: &Path, output: &Path, force: bool) -> Result<()> {
+pub fn run_query_ndjson(input: &Path, predicate: &RecordPredicate, fields: &[String]) -> Result<()> {
     let input = InputHandle::open(input)?;
     let mut reader = LogjetReader::new(input.into_buf_reader());
-    let mut output = open_output_with_policy(output, force)?;
+    let mut output = open_output_with_policy(Path::new("-"), true)?;
 
     while let Some(record) = reader.next_record()? {
-        for row in export_ndjson_objects(&record) {
+        if !predicate.matches(&record) {
+            continue;
+        }
+        for row in export_ndjson_objects(&record, fields) {
             serde_json::to_writer(&mut output, &row).map_err(|err| Error::Usage(format!("failed to serialise NDJSON row: {err}")))?;
             output.write_all(b"\n")?;
         }
@@ -48,20 +56,36 @@ fn run_ndjson(input: &Path, output: &Path, force: bool) -> Result<()> {
     Ok(())
 }
 
-fn export_ndjson_objects(record: &OwnedRecord) -> Vec<JsonValue> {
+fn run_ndjson(input: &Path, output: &Path, force: bool, fields: &[String]) -> Result<()> {
+    let input = InputHandle::open(input)?;
+    let mut reader = LogjetReader::new(input.into_buf_reader());
+    let mut output = open_output_with_policy(output, force)?;
+
+    while let Some(record) = reader.next_record()? {
+        for row in export_ndjson_objects(&record, fields) {
+            serde_json::to_writer(&mut output, &row).map_err(|err| Error::Usage(format!("failed to serialise NDJSON row: {err}")))?;
+            output.write_all(b"\n")?;
+        }
+    }
+
+    output.flush()?;
+    Ok(())
+}
+
+pub(crate) fn export_ndjson_objects(record: &OwnedRecord, fields: &[String]) -> Vec<JsonValue> {
     if record.record_type != RecordType::Logs {
         let mut obj = JsonMap::new();
         obj.insert("record_type".to_string(), JsonValue::String(record_kind_label(record.record_type).to_string()));
         obj.insert("timestamp".to_string(), JsonValue::String(format_timestamp(record.ts_unix_ns)));
         obj.insert("payload".to_string(), JsonValue::String(String::from_utf8_lossy(&record.payload).to_string()));
-        return vec![JsonValue::Object(obj)];
+        return vec![select_json_fields(obj, fields)];
     }
 
     let Ok(batch) = ExportLogsServiceRequest::decode(record.payload.as_slice()) else {
         let mut obj = JsonMap::new();
         obj.insert("timestamp".to_string(), JsonValue::String(format_timestamp(record.ts_unix_ns)));
         obj.insert("payload".to_string(), JsonValue::String(String::from_utf8_lossy(&record.payload).to_string()));
-        return vec![JsonValue::Object(obj)];
+        return vec![select_json_fields(obj, fields)];
     };
 
     let mut out = Vec::new();
@@ -71,22 +95,76 @@ fn export_ndjson_objects(record: &OwnedRecord) -> Vec<JsonValue> {
             let scope_attrs = scope_logs.scope.as_ref().map(|s| s.attributes.as_slice()).unwrap_or(&[]);
             for log_record in &scope_logs.log_records {
                 let mut obj = JsonMap::new();
-                obj.insert(
-                    "body".to_string(),
-                    JsonValue::String(log_record.body.as_ref().map(|v| format_any_value(Some(v))).filter(|s| !s.is_empty()).unwrap_or_default()),
-                );
-                obj.insert("timestamp".to_string(), JsonValue::String(format_timestamp(log_record.time_unix_nano.max(record.ts_unix_ns))));
-                if !log_record.event_name.is_empty() {
-                    obj.insert("event_name".to_string(), JsonValue::String(log_record.event_name.clone()));
+                if let Some(scope) = &scope_logs.scope {
+                    if !scope.name.is_empty() {
+                        obj.insert("scope_name".to_string(), JsonValue::String(scope.name.clone()));
+                    }
+                    if !scope.version.is_empty() {
+                        obj.insert("scope_version".to_string(), JsonValue::String(scope.version.clone()));
+                    }
                 }
+                insert_otlp_log_fields(&mut obj, log_record, record.ts_unix_ns);
                 flatten_otlp_attrs_into_json(&mut obj, resource_attrs);
                 flatten_otlp_attrs_into_json(&mut obj, scope_attrs);
                 flatten_otlp_attrs_into_json(&mut obj, &log_record.attributes);
-                out.push(JsonValue::Object(obj));
+                out.push(select_json_fields(obj, fields));
             }
         }
     }
     out
+}
+
+fn insert_otlp_log_fields(target: &mut JsonMap<String, JsonValue>, log_record: &LogRecord, fallback_ts_unix_ns: u64) {
+    target.insert(
+        "body".to_string(),
+        JsonValue::String(log_record.body.as_ref().map(|v| format_any_value(Some(v))).filter(|s| !s.is_empty()).unwrap_or_default()),
+    );
+    target.insert("timestamp".to_string(), JsonValue::String(format_timestamp(log_record.time_unix_nano.max(fallback_ts_unix_ns))));
+    if log_record.observed_time_unix_nano > 0 {
+        target.insert("observed_timestamp".to_string(), JsonValue::String(format_timestamp(log_record.observed_time_unix_nano)));
+    }
+    if log_record.severity_number != 0 {
+        target.insert("severity_number".to_string(), JsonValue::Number(log_record.severity_number.into()));
+    }
+    if !log_record.severity_text.is_empty() {
+        target.insert("severity_text".to_string(), JsonValue::String(log_record.severity_text.clone()));
+    }
+    if log_record.flags != 0 {
+        target.insert("flags".to_string(), JsonValue::Number(log_record.flags.into()));
+    }
+    if !log_record.event_name.is_empty() {
+        target.insert("event_name".to_string(), JsonValue::String(log_record.event_name.clone()));
+    }
+    if !log_record.trace_id.is_empty() {
+        target.insert("trace_id".to_string(), JsonValue::String(hex_encode(&log_record.trace_id)));
+    }
+    if !log_record.span_id.is_empty() {
+        target.insert("span_id".to_string(), JsonValue::String(hex_encode(&log_record.span_id)));
+    }
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for &byte in bytes {
+        out.push(HEX[(byte >> 4) as usize] as char);
+        out.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    out
+}
+
+fn select_json_fields(mut obj: JsonMap<String, JsonValue>, fields: &[String]) -> JsonValue {
+    if fields.is_empty() {
+        return JsonValue::Object(obj);
+    }
+
+    let mut selected = JsonMap::new();
+    for field in fields {
+        if let Some(value) = obj.remove(field) {
+            selected.insert(field.clone(), value);
+        }
+    }
+    JsonValue::Object(selected)
 }
 
 fn flatten_otlp_attrs_into_json(target: &mut JsonMap<String, JsonValue>, attrs: &[opentelemetry_proto::tonic::common::v1::KeyValue]) {
@@ -152,5 +230,97 @@ fn format_timestamp(ts_unix_ns: u64) -> String {
     match Utc.timestamp_opt(secs, nanos).single() {
         Some(ts) => ts.format("%Y-%m-%d %H:%M:%S.%f UTC").to_string(),
         None => ts_unix_ns.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod export_utst {
+    use super::{export_ndjson_objects, select_json_fields};
+    use logjet::{OwnedRecord, RecordType};
+    use opentelemetry_proto::tonic::collector::logs::v1::ExportLogsServiceRequest;
+    use opentelemetry_proto::tonic::common::v1::any_value::Value;
+    use opentelemetry_proto::tonic::common::v1::{AnyValue, InstrumentationScope, KeyValue};
+    use opentelemetry_proto::tonic::logs::v1::{LogRecord, ResourceLogs, ScopeLogs};
+    use opentelemetry_proto::tonic::resource::v1::Resource;
+    use prost::Message;
+    use serde_json::{Map as JsonMap, Value as JsonValue};
+
+    #[test]
+    fn select_json_fields_keeps_all_keys_when_unset() {
+        let mut obj = JsonMap::new();
+        obj.insert("body".to_string(), JsonValue::String("hello".to_string()));
+        obj.insert("timestamp".to_string(), JsonValue::String("now".to_string()));
+
+        let JsonValue::Object(selected) = select_json_fields(obj, &[]) else { panic!("expected object") };
+        assert_eq!(selected.len(), 2);
+        assert_eq!(selected.get("body"), Some(&JsonValue::String("hello".to_string())));
+        assert_eq!(selected.get("timestamp"), Some(&JsonValue::String("now".to_string())));
+    }
+
+    #[test]
+    fn select_json_fields_filters_to_requested_subset() {
+        let mut obj = JsonMap::new();
+        obj.insert("body".to_string(), JsonValue::String("hello".to_string()));
+        obj.insert("timestamp".to_string(), JsonValue::String("now".to_string()));
+        obj.insert("service_name".to_string(), JsonValue::String("svc".to_string()));
+
+        let fields = vec!["service_name".to_string(), "body".to_string()];
+        let JsonValue::Object(selected) = select_json_fields(obj, &fields) else { panic!("expected object") };
+        assert_eq!(selected.len(), 2);
+        assert_eq!(selected.get("service_name"), Some(&JsonValue::String("svc".to_string())));
+        assert_eq!(selected.get("body"), Some(&JsonValue::String("hello".to_string())));
+    }
+
+    #[test]
+    fn export_ndjson_objects_includes_core_otlp_log_fields() {
+        let batch = ExportLogsServiceRequest {
+            resource_logs: vec![ResourceLogs {
+                resource: Some(Resource {
+                    attributes: vec![KeyValue {
+                        key: "service.name".to_string(),
+                        value: Some(AnyValue { value: Some(Value::StringValue("demo-svc".to_string())) }),
+                    }],
+                    dropped_attributes_count: 0,
+                    entity_refs: Vec::new(),
+                }),
+                scope_logs: vec![ScopeLogs {
+                    scope: Some(InstrumentationScope {
+                        name: "demo.scope".to_string(),
+                        version: "1.2.3".to_string(),
+                        attributes: Vec::new(),
+                        dropped_attributes_count: 0,
+                    }),
+                    log_records: vec![LogRecord {
+                        time_unix_nano: 1_700_000_000_000_000_000,
+                        observed_time_unix_nano: 1_700_000_000_000_000_123,
+                        severity_number: 9,
+                        severity_text: "INFO".to_string(),
+                        body: Some(AnyValue { value: Some(Value::StringValue("hello".to_string())) }),
+                        attributes: Vec::new(),
+                        dropped_attributes_count: 0,
+                        flags: 3,
+                        trace_id: vec![0xaa, 0xbb, 0xcc, 0xdd],
+                        span_id: vec![0x11, 0x22],
+                        event_name: "demo.event".to_string(),
+                    }],
+                    schema_url: String::new(),
+                }],
+                schema_url: String::new(),
+            }],
+        };
+        let record = OwnedRecord { record_type: RecordType::Logs, seq: 1, ts_unix_ns: 1_700_000_000_000_000_000, payload: batch.encode_to_vec() };
+
+        let docs = export_ndjson_objects(&record, &[]);
+        let Some(obj) = docs.first().and_then(JsonValue::as_object) else { panic!("expected object") };
+        assert_eq!(obj.get("body"), Some(&JsonValue::String("hello".to_string())));
+        assert_eq!(obj.get("severity_text"), Some(&JsonValue::String("INFO".to_string())));
+        assert_eq!(obj.get("severity_number"), Some(&JsonValue::Number(9.into())));
+        assert_eq!(obj.get("event_name"), Some(&JsonValue::String("demo.event".to_string())));
+        assert_eq!(obj.get("scope_name"), Some(&JsonValue::String("demo.scope".to_string())));
+        assert_eq!(obj.get("scope_version"), Some(&JsonValue::String("1.2.3".to_string())));
+        assert_eq!(obj.get("service_name"), Some(&JsonValue::String("demo-svc".to_string())));
+        assert_eq!(obj.get("trace_id"), Some(&JsonValue::String("aabbccdd".to_string())));
+        assert_eq!(obj.get("span_id"), Some(&JsonValue::String("1122".to_string())));
+        assert!(obj.get("observed_timestamp").is_some());
     }
 }

--- a/ljx/src/commands/view/detail.rs
+++ b/ljx/src/commands/view/detail.rs
@@ -341,20 +341,62 @@ pub(super) fn export_ndjson_objects(detail: &DetailRecord) -> Vec<JsonValue> {
             let scope_attrs = scope_logs.scope.as_ref().map(|s| s.attributes.as_slice()).unwrap_or(&[]);
             for record in &scope_logs.log_records {
                 let mut obj = JsonMap::new();
-                obj.insert(
-                    "body".to_string(),
-                    JsonValue::String(record.body.as_ref().map(|v| format_any_value(Some(v))).filter(|s| !s.is_empty()).unwrap_or_default()),
-                );
-                obj.insert("timestamp".to_string(), JsonValue::String(format_timestamp(record.time_unix_nano.max(detail.meta.ts_unix_ns))));
-                if !record.event_name.is_empty() {
-                    obj.insert("event_name".to_string(), JsonValue::String(record.event_name.clone()));
+                if let Some(scope) = &scope_logs.scope {
+                    if !scope.name.is_empty() {
+                        obj.insert("scope_name".to_string(), JsonValue::String(scope.name.clone()));
+                    }
+                    if !scope.version.is_empty() {
+                        obj.insert("scope_version".to_string(), JsonValue::String(scope.version.clone()));
+                    }
                 }
+                insert_otlp_log_fields(&mut obj, record, detail.meta.ts_unix_ns);
                 flatten_otlp_attrs_into_json(&mut obj, resource_attrs);
                 flatten_otlp_attrs_into_json(&mut obj, scope_attrs);
                 flatten_otlp_attrs_into_json(&mut obj, &record.attributes);
                 out.push(JsonValue::Object(obj));
             }
         }
+    }
+    out
+}
+
+fn insert_otlp_log_fields(
+    target: &mut JsonMap<String, JsonValue>, record: &opentelemetry_proto::tonic::logs::v1::LogRecord, fallback_ts_unix_ns: u64,
+) {
+    target.insert(
+        "body".to_string(),
+        JsonValue::String(record.body.as_ref().map(|v| format_any_value(Some(v))).filter(|s| !s.is_empty()).unwrap_or_default()),
+    );
+    target.insert("timestamp".to_string(), JsonValue::String(format_timestamp(record.time_unix_nano.max(fallback_ts_unix_ns))));
+    if record.observed_time_unix_nano > 0 {
+        target.insert("observed_timestamp".to_string(), JsonValue::String(format_timestamp(record.observed_time_unix_nano)));
+    }
+    if record.severity_number != 0 {
+        target.insert("severity_number".to_string(), JsonValue::Number(record.severity_number.into()));
+    }
+    if !record.severity_text.is_empty() {
+        target.insert("severity_text".to_string(), JsonValue::String(record.severity_text.clone()));
+    }
+    if record.flags != 0 {
+        target.insert("flags".to_string(), JsonValue::Number(record.flags.into()));
+    }
+    if !record.event_name.is_empty() {
+        target.insert("event_name".to_string(), JsonValue::String(record.event_name.clone()));
+    }
+    if !record.trace_id.is_empty() {
+        target.insert("trace_id".to_string(), JsonValue::String(hex_encode(&record.trace_id)));
+    }
+    if !record.span_id.is_empty() {
+        target.insert("span_id".to_string(), JsonValue::String(hex_encode(&record.span_id)));
+    }
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for &byte in bytes {
+        out.push(HEX[(byte >> 4) as usize] as char);
+        out.push(HEX[(byte & 0x0f) as usize] as char);
     }
     out
 }

--- a/ljx/src/main.rs
+++ b/ljx/src/main.rs
@@ -8,7 +8,7 @@ mod predicate;
 
 use clap::FromArgMatches;
 
-use crate::cli::{Cli, Command};
+use crate::cli::{Cli, Command, ExportFormat};
 use crate::error::{Error, Result};
 
 fn main() {
@@ -20,12 +20,26 @@ fn main() {
 
 fn run() -> Result<()> {
     let mut command = cli::build_cli();
+    if std::env::args_os().len() == 1 {
+        command.print_long_help()?;
+        println!();
+        return Ok(());
+    }
     let mut matches = command.get_matches_mut();
     let cli = Cli::from_arg_matches_mut(&mut matches).map_err(|err| crate::error::Error::Usage(err.to_string()))?;
     if let Some(format) = cli.export.as_deref() {
         let input = cli.input.ok_or_else(|| Error::Usage("missing export input; use `ljx --export <format> <input> -o <output>`".to_string()))?;
         let output = cli.output.ok_or_else(|| Error::Usage("missing export output; use `ljx --export <format> <input> -o <output>`".to_string()))?;
-        return commands::export::run(format, &input, &output, cli.force);
+        return commands::export::run(format, &input, &output, cli.force, &cli.fields);
+    }
+    if let Some(input) = cli.input.as_deref() {
+        let predicate = cli.predicate.build()?;
+        return match cli.format.unwrap_or(ExportFormat::Ndjson) {
+            ExportFormat::Ndjson => commands::export::run_query_ndjson(input, &predicate, &cli.fields),
+        };
+    }
+    if cli.format.is_some() || cli.predicate.has_filters() {
+        return Err(Error::Usage("missing query input; use `ljx <input> [--format ndjson] [FILTER OPTIONS]`".to_string()));
     }
 
     match cli.command {

--- a/ljx/src/predicate.rs
+++ b/ljx/src/predicate.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 
-use clap::{ArgGroup, Args, CommandFactory, FromArgMatches, Parser, ValueEnum};
+use clap::{Args, CommandFactory, FromArgMatches, Parser, ValueEnum};
 use logjet::{OwnedRecord, RecordType};
 use opentelemetry_proto::tonic::collector::logs::v1::ExportLogsServiceRequest;
 use prost::Message;
@@ -67,34 +67,29 @@ impl FieldFilter {
 }
 
 #[derive(Debug, Clone, Args, Default)]
-#[command(group(
-    ArgGroup::new("payload_match")
-        .args(["grep", "fixed_string"])
-        .multiple(false)
-))]
 pub struct PredicateArgs {
-    #[arg(long = "type", value_enum)]
+    #[arg(long = "type", value_enum, help = "Match only one record type")]
     pub record_type: Option<RecordKind>,
 
-    #[arg(long)]
+    #[arg(long, help = "Match records with sequence >= this value")]
     pub seq_min: Option<u64>,
 
-    #[arg(long)]
+    #[arg(long, help = "Match records with sequence <= this value")]
     pub seq_max: Option<u64>,
 
-    #[arg(long)]
+    #[arg(long, help = "Match records with timestamp >= this unix-ns value")]
     pub ts_min: Option<u64>,
 
-    #[arg(long)]
+    #[arg(long, help = "Match records with timestamp <= this unix-ns value")]
     pub ts_max: Option<u64>,
 
-    #[arg(short = 'e', long = "grep", value_name = "PATTERN")]
-    pub grep: Option<String>,
+    #[arg(short = 'e', long = "grep", value_name = "PATTERN", help = "Regex payload matcher; repeat for AND semantics")]
+    pub grep: Vec<String>,
 
-    #[arg(short = 'F', long = "fixed-string", value_name = "TEXT")]
-    pub fixed_string: Option<String>,
+    #[arg(short = 'F', long = "fixed-string", value_name = "TEXT", help = "Literal payload matcher; repeat for AND semantics")]
+    pub fixed_string: Vec<String>,
 
-    #[arg(short = 'i', long = "ignore-case")]
+    #[arg(short = 'i', long = "ignore-case", help = "Apply case-insensitive matching to all payload matchers")]
     pub ignore_case: bool,
 }
 
@@ -105,7 +100,7 @@ pub struct RecordPredicate {
     seq_max: Option<u64>,
     ts_min: Option<u64>,
     ts_max: Option<u64>,
-    payload_matcher: Option<PayloadMatcher>,
+    payload_matchers: Vec<PayloadMatcher>,
     pub field_filter: FieldFilter,
 }
 
@@ -115,15 +110,25 @@ struct PayloadMatcher {
 }
 
 impl PredicateArgs {
+    pub fn has_filters(&self) -> bool {
+        self.record_type.is_some()
+            || self.seq_min.is_some()
+            || self.seq_max.is_some()
+            || self.ts_min.is_some()
+            || self.ts_max.is_some()
+            || !self.grep.is_empty()
+            || !self.fixed_string.is_empty()
+            || self.ignore_case
+    }
+
     pub fn build(self) -> Result<RecordPredicate> {
-        let payload_matcher = match (self.grep, self.fixed_string) {
-            (Some(pattern), None) => Some(PayloadMatcher::new(&pattern, false, self.ignore_case)?),
-            (None, Some(text)) => Some(PayloadMatcher::new(&text, true, self.ignore_case)?),
-            (None, None) => None,
-            (Some(_), Some(_)) => {
-                return Err(Error::Usage("choose either -e/--grep or -F/--fixed-string, not both".to_string()));
-            }
-        };
+        let mut payload_matchers = Vec::with_capacity(self.grep.len() + self.fixed_string.len());
+        for pattern in self.grep {
+            payload_matchers.push(PayloadMatcher::new(&pattern, false, self.ignore_case)?);
+        }
+        for text in self.fixed_string {
+            payload_matchers.push(PayloadMatcher::new(&text, true, self.ignore_case)?);
+        }
 
         Ok(RecordPredicate {
             record_type: self.record_type.map(Into::into),
@@ -131,7 +136,7 @@ impl PredicateArgs {
             seq_max: self.seq_max,
             ts_min: self.ts_min,
             ts_max: self.ts_max,
-            payload_matcher,
+            payload_matchers,
             field_filter: FieldFilter::default(),
         })
     }
@@ -152,8 +157,8 @@ pub fn parse_filter_query(query: &str, mode: FilterMode) -> Result<RecordPredica
     // Bare text in the TUI stays ergonomic and depends on the active filter mode.
     if !trimmed.starts_with('-') {
         return match mode {
-            FilterMode::Strings => PredicateArgs { fixed_string: Some(trimmed.to_string()), ..PredicateArgs::default() }.build(),
-            FilterMode::Regex => PredicateArgs { grep: Some(trimmed.to_string()), ..PredicateArgs::default() }.build(),
+            FilterMode::Strings => PredicateArgs { fixed_string: vec![trimmed.to_string()], ..PredicateArgs::default() }.build(),
+            FilterMode::Regex => PredicateArgs { grep: vec![trimmed.to_string()], ..PredicateArgs::default() }.build(),
         };
     }
 
@@ -195,10 +200,10 @@ impl RecordPredicate {
         {
             return false;
         }
-        if let Some(matcher) = &self.payload_matcher
-            && !matcher.is_match(&record.payload)
-        {
-            return false;
+        for matcher in &self.payload_matchers {
+            if !matcher.is_match(&record.payload) {
+                return false;
+            }
         }
         if !self.field_filter.matches_payload(&record.payload) {
             return false;

--- a/ljx/tests/unit/cli_utst.rs
+++ b/ljx/tests/unit/cli_utst.rs
@@ -36,8 +36,39 @@ fn top_level_export_force_parses() {
 }
 
 #[test]
+fn top_level_query_parses_literal_filter() {
+    let cli = Cli::try_parse_from(["ljx", "input.logjet", "-F", "error"]).expect("cli parses");
+    assert_eq!(cli.input, Some(PathBuf::from("input.logjet")));
+    assert!(matches!(cli.format, None));
+    assert_eq!(cli.predicate.fixed_string, vec!["error".to_string()]);
+}
+
+#[test]
+fn top_level_query_accepts_explicit_ndjson_format() {
+    let cli = Cli::try_parse_from(["ljx", "--format", "ndjson", "input.logjet", "-e", "error|panic"]).expect("cli parses");
+    assert_eq!(cli.input, Some(PathBuf::from("input.logjet")));
+    assert!(matches!(cli.format, Some(crate::cli::ExportFormat::Ndjson)));
+    assert_eq!(cli.predicate.grep, vec!["error|panic".to_string()]);
+}
+
+#[test]
+fn top_level_query_parses_repeated_literal_and_regex_filters() {
+    let cli = Cli::try_parse_from(["ljx", "input.logjet", "-F", "foo", "-F", "bar", "-e", "baz|qux", "-e", "zap"]).expect("cli parses");
+    assert_eq!(cli.predicate.fixed_string, vec!["foo".to_string(), "bar".to_string()]);
+    assert_eq!(cli.predicate.grep, vec!["baz|qux".to_string(), "zap".to_string()]);
+}
+
+#[test]
+fn top_level_query_parses_field_selection() {
+    let cli = Cli::try_parse_from(["ljx", "input.logjet", "--fields", "body,timestamp", "--fields", "service_name"]).expect("cli parses");
+    assert_eq!(cli.fields, vec!["body".to_string(), "timestamp".to_string(), "service_name".to_string()]);
+}
+
+#[test]
 fn help_lists_current_export_formats() {
     let help = build_cli().render_long_help().to_string();
+    assert!(help.contains("ljx <INPUT> [--format <FORMAT>] [FILTER OPTIONS]"));
+    assert!(help.contains("--fields <KEY[,KEY...]>"));
     assert!(help.contains("--export <FORMAT>"));
     assert!(help.contains("Export one .logjet input to a built-in or plugin format: ndjson"));
     assert!(!help.contains("Built-in export formats:"));

--- a/ljx/tests/unit/cli_utst.rs
+++ b/ljx/tests/unit/cli_utst.rs
@@ -39,7 +39,7 @@ fn top_level_export_force_parses() {
 fn top_level_query_parses_literal_filter() {
     let cli = Cli::try_parse_from(["ljx", "input.logjet", "-F", "error"]).expect("cli parses");
     assert_eq!(cli.input, Some(PathBuf::from("input.logjet")));
-    assert!(matches!(cli.format, None));
+    assert!(cli.format.is_none());
     assert_eq!(cli.predicate.fixed_string, vec!["error".to_string()]);
 }
 

--- a/ljx/tests/unit/commands/view_ut.rs
+++ b/ljx/tests/unit/commands/view_ut.rs
@@ -606,6 +606,8 @@ fn export_current_results_writes_ndjson_from_filtered_view() {
     assert_eq!(docs.len(), 2);
     assert_eq!(docs[0]["body"], "second gps");
     assert_eq!(docs[0]["event_name"], "demo.log.utf8");
+    assert_eq!(docs[0]["severity_text"], "INFO");
+    assert_eq!(docs[0]["severity_number"], 9);
     assert_eq!(docs[0]["demo_channel"][0], "AndroidGeoLocationListener");
     assert_eq!(docs[1]["body"], "third gps");
 
@@ -637,6 +639,7 @@ fn export_current_results_can_export_selected_row_only() {
     let docs = read_ndjson(&output);
     assert_eq!(docs.len(), 1);
     assert_eq!(docs[0]["body"], "second gps");
+    assert_eq!(docs[0]["severity_text"], "INFO");
 
     let _ = std::fs::remove_file(input);
     let _ = std::fs::remove_file(output);

--- a/ljx/tests/unit/predicate_ut.rs
+++ b/ljx/tests/unit/predicate_ut.rs
@@ -7,7 +7,7 @@ fn sample_record(payload: &[u8]) -> OwnedRecord {
 
 #[test]
 fn fixed_string_match_is_literal() {
-    let predicate = PredicateArgs { fixed_string: Some("java.crap.failed".to_string()), ..PredicateArgs::default() }.build().unwrap();
+    let predicate = PredicateArgs { fixed_string: vec!["java.crap.failed".to_string()], ..PredicateArgs::default() }.build().unwrap();
 
     assert!(predicate.matches(&sample_record(b"xxx java.crap.failed yyy")));
     assert!(!predicate.matches(&sample_record(b"javaXcrapXfailed")));
@@ -15,7 +15,7 @@ fn fixed_string_match_is_literal() {
 
 #[test]
 fn regex_match_supports_wildcards() {
-    let predicate = PredicateArgs { grep: Some(r"java\..*\.bs".to_string()), ..PredicateArgs::default() }.build().unwrap();
+    let predicate = PredicateArgs { grep: vec![r"java\..*\.bs".to_string()], ..PredicateArgs::default() }.build().unwrap();
 
     assert!(predicate.matches(&sample_record(b"java.very.long.bs")));
     assert!(!predicate.matches(&sample_record(b"java.very.long.cs")));
@@ -23,8 +23,8 @@ fn regex_match_supports_wildcards() {
 
 #[test]
 fn ignore_case_applies_to_fixed_string_and_regex() {
-    let fixed = PredicateArgs { fixed_string: Some("error".to_string()), ignore_case: true, ..PredicateArgs::default() }.build().unwrap();
-    let regex = PredicateArgs { grep: Some("error".to_string()), ignore_case: true, ..PredicateArgs::default() }.build().unwrap();
+    let fixed = PredicateArgs { fixed_string: vec!["error".to_string()], ignore_case: true, ..PredicateArgs::default() }.build().unwrap();
+    let regex = PredicateArgs { grep: vec!["error".to_string()], ignore_case: true, ..PredicateArgs::default() }.build().unwrap();
 
     let record = sample_record(b"prefix eRrOr suffix");
     assert!(fixed.matches(&record));
@@ -39,7 +39,7 @@ fn matcher_combines_with_record_fields() {
         seq_max: Some(45),
         ts_min: Some(1_699_999_999),
         ts_max: Some(1_700_000_001),
-        fixed_string: Some("hello".to_string()),
+        fixed_string: vec!["hello".to_string()],
         ..PredicateArgs::default()
     }
     .build()
@@ -51,9 +51,37 @@ fn matcher_combines_with_record_fields() {
 
 #[test]
 fn invalid_regex_is_reported() {
-    let error = PredicateArgs { grep: Some("(".to_string()), ..PredicateArgs::default() }.build().unwrap_err();
+    let error = PredicateArgs { grep: vec!["(".to_string()], ..PredicateArgs::default() }.build().unwrap_err();
 
     assert!(error.to_string().contains("invalid payload matcher"));
+}
+
+#[test]
+fn repeated_fixed_strings_are_combined_with_and_semantics() {
+    let predicate = PredicateArgs { fixed_string: vec!["foo".to_string(), "bar".to_string()], ..PredicateArgs::default() }.build().unwrap();
+
+    assert!(predicate.matches(&sample_record(b"prefix foo and bar suffix")));
+    assert!(!predicate.matches(&sample_record(b"only foo here")));
+}
+
+#[test]
+fn repeated_regexes_are_combined_with_and_semantics() {
+    let predicate = PredicateArgs { grep: vec!["foo".to_string(), "bar|baz".to_string()], ..PredicateArgs::default() }.build().unwrap();
+
+    assert!(predicate.matches(&sample_record(b"foo plus baz")));
+    assert!(predicate.matches(&sample_record(b"bar comes with foo")));
+    assert!(!predicate.matches(&sample_record(b"foo alone")));
+}
+
+#[test]
+fn fixed_string_and_regex_can_be_mixed() {
+    let predicate =
+        PredicateArgs { fixed_string: vec!["customer-123".to_string()], grep: vec!["error|panic".to_string()], ..PredicateArgs::default() }
+            .build()
+            .unwrap();
+
+    assert!(predicate.matches(&sample_record(b"panic for customer-123")));
+    assert!(!predicate.matches(&sample_record(b"panic for customer-999")));
 }
 
 #[test]

--- a/tests/ljx_cli.rs
+++ b/tests/ljx_cli.rs
@@ -86,12 +86,8 @@ fn ljx_filters_real_ljd_output_from_mock_emitter() -> io::Result<()> {
     fs::write(&filtered_stdout, &stdout_output.stdout)?;
     assert_eq!(read_logjet_messages(&filtered_stdout)?, vec!["ERROR boom".to_string(), "eRrOr splash".to_string()]);
 
-    let invalid = run_ljx(["count".as_ref(), spool_path.as_os_str()], &["-F", "error", "-e", "panic"])?;
-    assert!(!invalid.status.success());
-    assert!(
-        String::from_utf8_lossy(&invalid.stderr).contains("cannot be used with")
-            || String::from_utf8_lossy(&invalid.stderr).contains("choose either")
-    );
+    assert_eq!(run_ljx_count(&spool_path, &["-F", "error", "-e", "splash", "-i"])?, "1");
+    assert_eq!(run_ljx_count(&spool_path, &["-F", "error", "-e", "panic", "-i"])?, "0");
 
     Ok(())
 }


### PR DESCRIPTION
This PR allows `ljx` to be used from CLI by searching in grep-style strings matches and regular expressions, exporting the output in NDJSON. Further transformations one may do with `jq` tool.